### PR TITLE
Adding different commands for creating and applying migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "start": "next start",
     "lint": "next lint",
     "format": "prettier --write .",
-    "prisma:migrate": "prisma migrate dev --name",
+    "prisma:create": "prisma migrate dev --name",
+    "prisma:apply": "prisma migrate dev",
     "prisma:generate": "prisma generate"
   },
   "dependencies": {


### PR DESCRIPTION
Separamos los comandos `prisma migrate dev --name` y `prisma migrate dev` para que cada uno cree y aplique migraciones, respectivamente.