### PR TITLE
Visual adjustments on course page

### DIFF
--- a/src/app/(platform)/courses/[courseId]/page.tsx
+++ b/src/app/(platform)/courses/[courseId]/page.tsx
@@ -22,7 +22,7 @@ const Course = ({ params: { courseId } }: { params: { courseId: string } }) => {
   if (!course) return <div>El curso no existe.</div>;
 
   return (
-    <div className="mt-4 md:px-20">
+    <div className="mt-4 md:mb-8 md:px-20">
       <Breadcrumb className="mb-4">
         <BreadcrumbList>
           <BreadcrumbItem>

--- a/src/app/(platform)/layout.tsx
+++ b/src/app/(platform)/layout.tsx
@@ -34,7 +34,7 @@ const PlatformLayout = async ({
         <span className="text-sm font-semibold">programaConNosotros</span>
       </div>
 
-      <main className="p-4 pt-16 md:p-0 md:pt-1 w-full">{children}</main>
+      <main className="p-4 pt-16 md:p-0 md:pt-1 md:max-w-7xl w-full">{children}</main>
     </SidebarProvider>
   );
 };

--- a/src/app/(platform)/layout.tsx
+++ b/src/app/(platform)/layout.tsx
@@ -34,7 +34,7 @@ const PlatformLayout = async ({
         <span className="text-sm font-semibold">programaConNosotros</span>
       </div>
 
-      <main className="p-4 pt-16 md:p-0 md:pt-1">{children}</main>
+      <main className="p-4 pt-16 md:p-0 md:pt-1 w-full">{children}</main>
     </SidebarProvider>
   );
 };


### PR DESCRIPTION
The width of the main layout is adjusted to take the full width and a max-width of 1280px is added. This is so that in the courses page, when there is only 1 video in a course, this will occupy the entire width of the container, as well as other courses that have more than one video. In addition a padding bottom is added to separate the video.

Before:
1- A single video
![courses-before](https://github.com/user-attachments/assets/f6994578-71db-4c89-943b-f3bd2003aa27)
2- More than one video
![courses-before-2](https://github.com/user-attachments/assets/04a91635-79ee-40ae-b955-c01a20377c63)

After:
1- A single video
![courses-after](https://github.com/user-attachments/assets/daa268d5-5fb7-40ed-b70b-407ab13129b9)
2- More than one video
![courses-after-2](https://github.com/user-attachments/assets/fe06330f-6d96-4ca2-b53a-17ba46183aea)

