### PR TITLE
feat: add edit profile button for user profiles

### DIFF
--- a/src/app/(platform)/profile/[id]/page.tsx
+++ b/src/app/(platform)/profile/[id]/page.tsx
@@ -3,9 +3,11 @@ import { AdviseCard } from '@/components/advises/advise-card';
 import { ProfileForm } from '@/components/profile/profile-form';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import prisma from '@/lib/prisma';
-import { Linkedin, Twitter } from 'lucide-react';
+import { Linkedin, Twitter, Pencil } from 'lucide-react';
 import { notFound } from 'next/navigation';
+import Link from 'next/link';
 import { LanguageCoinsContainer } from '@/components/profile/language-coins-container';
 
 export const revalidate = 0;
@@ -72,6 +74,8 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
       }))
     : [];
 
+  const isOwnProfile = session?.user?.id === params.id;
+
   return (
     <div className="mt-4 md:max-w-screen-xl md:px-20">
       <Card>
@@ -83,6 +87,17 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
             </Avatar>
             <div>
               <h1 className="text-2xl font-bold">{user.name}</h1>
+              {isOwnProfile && (
+                <Link href="/profile">
+                  <Button
+                    variant="link"
+                    className="text-gray-400 hover:text-white p-0 h-auto text-sm flex items-center gap-1 mt-1"
+                  >
+                    <Pencil className="h-3 w-3" />
+                    <span>Editar perfil</span>
+                  </Button>
+                </Link>
+              )}
             </div>
           </div>
           <div className="space-y-2">


### PR DESCRIPTION
# Agregar botón "Editar perfil" en página de consejos

## Descripción
Se implementó un botón de "Editar perfil" en la página de perfil del usuario que permite una redirección directa a la página de edición del perfil. Este botón solo es visible cuando el usuario está viendo su propio perfil.

## Cambios realizados
- **Botón "Editar perfil":** Agregado debajo del nombre del usuario.
- **Lógica de visibilidad condicional:** El botón se muestra únicamente cuando `session?.user?.id` coincide con `params.id`.
- **Redirección:** Integrada la navegación a la página de edición de perfil.
- **Diseño consistente:** Se mantuvo la consistencia visual con el diseño existente.

## Detalles técnicos
- **Ubicación del archivo:**  
  `src/app/(platform)/profile/[id]/page.tsx`
- **Componentes utilizados:**
  - *Link* de Next.js para la navegación.
  - *Button* de los componentes UI.
  - *Pencil* de Lucide icons para la iconografía.
- **Lógica de visibilidad:**  
  El botón solo se muestra cuando `session?.user?.id` coincide con `params.id`.

## Comportamiento
- **Usuario viendo su propio perfil:**  
  - Visualiza el botón "Editar perfil".
  - Puede hacer clic en el botón para editar su información.
- **Usuario viendo otro perfil:**  
  - No se muestra el botón de edición.
- **Redirección:**  
  - Al hacer clic en el botón, el usuario es llevado a la página `/profile` donde puede editar su información.


https://github.com/user-attachments/assets/30d40109-c4cb-4204-a2d3-93b07276f28b

