### PR TITLE
[PCN-#81] - Reparar vista mobile del toggle button del sidebar.

### DIFF
--- a/src/app/(platform)/layout.tsx
+++ b/src/app/(platform)/layout.tsx
@@ -30,11 +30,12 @@ const PlatformLayout = async ({
       <AppSidebar user={user} />
 
       <div className="fixed left-0 top-0 z-50 mb-4 flex h-12 w-full items-center gap-3 border-b border-border bg-background px-4 md:hidden">
+        <SidebarTrigger />
         <span className="text-sm font-semibold">programaConNosotros</span>
       </div>
 
       <main className="relative w-full p-4 pt-16 md:p-0 md:pt-1">
-        <SidebarTrigger className="absolute md:left-6 md:top-6" />
+        <SidebarTrigger className="absolute hidden md:block md:left-6 md:top-6" />
         {children}
       </main>
     </SidebarProvider>


### PR DESCRIPTION
Solucion al issue #81 donde se repara la vista mobile del sidebar trigger en la home page ya que se solapaba con el mensaje de bienvenida:

Error:

![sidebar-problem](https://github.com/user-attachments/assets/6119cfc9-2c79-4217-bc87-f2622fb183fe)


Solucion:

![sidebar-fixed](https://github.com/user-attachments/assets/7c30c215-eb53-4d42-9ec7-057be8ac1e80)
