### PR TITLE
[PCN #126] - Reparar vista mensaje de carga

### DIFF
--- a/src/app/(platform)/loading.tsx
+++ b/src/app/(platform)/loading.tsx
@@ -1,3 +1,10 @@
-const Loading = () => <p className="p-8">Cargando...</p>;
+const Loading = () => (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+        <div className="flex items-center gap-3 rounded-lg bg-background/95 px-6 py-3 text-base font-semibold text-muted-foreground shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/60">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            Cargando...
+        </div>
+    </div>
+);
 
 export default Loading;

--- a/src/components/advises/advises-list.tsx
+++ b/src/components/advises/advises-list.tsx
@@ -10,14 +10,11 @@ import { Heading2 } from '../ui/heading-2';
 export const AdvisesList = ({ session }: { session: (Session & { user: User }) | null }) => {
   const {
     data: advises = [],
-    isLoading,
     refetch,
   } = useQuery({
     queryKey: ['advises'],
     queryFn: () => fetchAdvises(1),
   });
-
-  if (isLoading) return <div>Cargando...</div>;
 
   return (
     <div className="relative">


### PR DESCRIPTION
Solucion al issue #126 donde se repara y mejora la vista del mensaje de carga global y se elimina el mensaje duplicado en advices-list.tsx:

Error:

![loading-message-problem](https://github.com/user-attachments/assets/4c7184ad-94db-4daf-8b72-3ab0fed8ed33)

Solucion:
  
  - Desktop:
  
![loading-message-fixed](https://github.com/user-attachments/assets/b36bb113-f9f8-4e60-84fc-c02c08b22a82)

  - Mobile:
  
![loading-message-mobile](https://github.com/user-attachments/assets/988e6bfe-9731-419f-ac1f-65b35c9e2207)
