### PR TITLE
[PCN-159 ] Error en la funcionalidad de restablecimiento de contraseña + fix en sign up

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -8,3 +8,4 @@ DATABASE_URL=
 
 # Database direct connection string
 DIRECT_URL=
+RESEND_API_KEY=

--- a/src/actions/auth/reset-password.ts
+++ b/src/actions/auth/reset-password.ts
@@ -36,6 +36,7 @@ export const resetPassword = async (email: string) => {
   });
 
   if (error) {
+    console.error(error);
     throw new Error('Error sending email');
   }
 };

--- a/src/actions/auth/sign-up.ts
+++ b/src/actions/auth/sign-up.ts
@@ -8,25 +8,19 @@ import { redirect } from 'next/navigation';
 
 // TODO: Improvement: Use same schema for client and server.
 
-const formSchema = z
-  .object({
-    name: z
-      .string()
-      .trim()
-      .min(2, 'El nombre debe tener al menos 2 caracteres')
-      .max(100, 'El nombre no puede tener más de 100 caracteres')
-      .regex(
-        /^[a-zA-ZÀ-ÿ\s]+$/,
-        'El nombre solo puede contener letras (a-z, A-Z) y espacios. No se permiten números ni caracteres especiales',
-      ),
-    email: z.string().email('Correo electrónico inválido'),
-    password: z.string().min(8, 'La contraseña debe tener al menos 8 caracteres'),
-    confirmPassword: z.string(),
-  })
-  .refine((data) => data.password === data.confirmPassword, {
-    message: 'Las contraseñas no coinciden',
-    path: ['confirmPassword'],
-  });
+const formSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(2, 'El nombre debe tener al menos 2 caracteres')
+    .max(100, 'El nombre no puede tener más de 100 caracteres')
+    .regex(
+      /^[a-zA-ZÀ-ÿ\s]+$/,
+      'El nombre solo puede contener letras (a-z, A-Z) y espacios. No se permiten números ni caracteres especiales',
+    ),
+  email: z.string().email('Correo electrónico inválido'),
+  password: z.string().min(8, 'La contraseña debe tener al menos 8 caracteres'),
+});
 
 export const signUp = async (data: z.infer<typeof formSchema>) => {
   const cleanedData = formSchema.parse(data);

--- a/src/actions/auth/sign-up.ts
+++ b/src/actions/auth/sign-up.ts
@@ -5,25 +5,12 @@ import { z } from 'zod';
 import bcrypt from 'bcryptjs';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
+import { signUpSchema } from '@/lib/validations/auth-schemas';
 
-// TODO: Improvement: Use same schema for client and server.
-
-const formSchema = z.object({
-  name: z
-    .string()
-    .trim()
-    .min(2, 'El nombre debe tener al menos 2 caracteres')
-    .max(100, 'El nombre no puede tener más de 100 caracteres')
-    .regex(
-      /^[a-zA-ZÀ-ÿ\s]+$/,
-      'El nombre solo puede contener letras (a-z, A-Z) y espacios. No se permiten números ni caracteres especiales',
-    ),
-  email: z.string().email('Correo electrónico inválido'),
-  password: z.string().min(8, 'La contraseña debe tener al menos 8 caracteres'),
-});
+const formSchema = signUpSchema;
 
 export const signUp = async (data: z.infer<typeof formSchema>) => {
-  const cleanedData = formSchema.parse(data);
+  const { confirmPassword, ...cleanedData } = formSchema.parse(data);
 
   const hashedPassword = await bcrypt.hash(cleanedData.password, 10);
 

--- a/src/app/auth/sign-up/page.tsx
+++ b/src/app/auth/sign-up/page.tsx
@@ -16,26 +16,9 @@ import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import * as z from 'zod';
 import { LogIn, UserPlus, SquareAsterisk, ArrowLeft } from 'lucide-react';
+import { signUpSchema } from '@/lib/validations/auth-schemas';
 
-const formSchema = z
-  .object({
-    name: z
-      .string()
-      .trim()
-      .min(2, 'El nombre debe tener al menos 2 caracteres')
-      .max(100, 'El nombre no puede tener más de 100 caracteres')
-      .regex(
-        /^[a-zA-ZÀ-ÿ\s]+$/,
-        'El nombre solo puede contener letras (a-z, A-Z) y espacios. No se permiten números ni caracteres especiales',
-      ),
-    email: z.string().email('Correo electrónico inválido'),
-    password: z.string().min(8, 'La contraseña debe tener al menos 8 caracteres'),
-    confirmPassword: z.string(),
-  })
-  .refine((data) => data.password === data.confirmPassword, {
-    message: 'Las contraseñas no coinciden',
-    path: ['confirmPassword'],
-  });
+const formSchema = signUpSchema;
 
 export default function SignUpPage() {
   const form = useForm<z.infer<typeof formSchema>>({

--- a/src/lib/validations/auth-schemas.ts
+++ b/src/lib/validations/auth-schemas.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export const signUpSchema = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(2, 'El nombre debe tener al menos 2 caracteres')
+      .max(100, 'El nombre no puede tener más de 100 caracteres')
+      .regex(
+        /^[a-zA-ZÀ-ÿ\s]+$/,
+        'El nombre solo puede contener letras (a-z, A-Z) y espacios. No se permiten números ni caracteres especiales',
+      ),
+    email: z.string().email('Correo electrónico inválido'),
+    password: z.string().min(8, 'La contraseña debe tener al menos 8 caracteres'),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: 'Las contraseñas no coinciden',
+    path: ['confirmPassword'],
+  });
+
+// Podemos agregar más esquemas relacionados aquí
+// Por ejemplo:
+// export const signInSchema = z.object({ ... });
+// export const resetPasswordSchema = z.object({ ... });


### PR DESCRIPTION
Solución al Issue #159  y un bug en sign up causado por el formSchema en la server action correspondiente.

## 🔧 Características agregadas
* Se corrigió el bug de Sign up.
* Se corrigió el bug al restablecer la contraseña
* Se extrajo lógica reutilzable del formSchema de signUp en un nuevo archivo.
* Nueva variable de entorno `RESEND_API_KEY`

### Detalle del nuevo módulo
Se colocó en la carpeta `lib/validations/auth-schemas.ts`.

### Explicación para el deploy
Asegurarse que la variable de entorno correspondiente a la API Key de Resend tenga un valor. Para esto se agregó una variable nueva en el `.env.template`

## 📂 Archivos relevantes

Archivo| Descripción
-- | --
app/auth/sign-up/page.tsx | Formulario de sign up
lib/validations/auth-schemas.ts | Nuevo módulo para schemas de validación
src/actions/sign-up.ts | Server action del sign up 
.env.template | Plantilla de .env

## Nota para testing local
En el archivo `reset-password.ts` se debe reemplazar el atributo `from` con lo siguiente:
`from: 'onboarding@resend.dev'`


##  🎥 Video

https://github.com/user-attachments/assets/96cc1587-6e8f-4fe2-8cdd-6704a4a8865c


![imagen](https://github.com/user-attachments/assets/b242ccb7-32a4-45cd-893e-54ff3ac4653b)

