### PR TITLE
[PCN-148] Validación incorrecta del campo de contraseña al crear una cuenta #148

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -8,3 +8,4 @@ DATABASE_URL=
 
 # Database direct connection string
 DIRECT_URL=
+RESEND_API_KEY=

--- a/src/actions/auth/reset-password.ts
+++ b/src/actions/auth/reset-password.ts
@@ -36,7 +36,7 @@ export const resetPassword = async (email: string) => {
   });
 
   if (error) {
-    console.error(error);
+    console.error('Failed to send reset password email:', error.message || 'Unknown error');
     throw new Error('Error sending email');
   }
 };

--- a/src/actions/auth/reset-password.ts
+++ b/src/actions/auth/reset-password.ts
@@ -36,6 +36,7 @@ export const resetPassword = async (email: string) => {
   });
 
   if (error) {
+    console.error(error);
     throw new Error('Error sending email');
   }
 };

--- a/src/actions/auth/sign-up.ts
+++ b/src/actions/auth/sign-up.ts
@@ -8,25 +8,19 @@ import { redirect } from 'next/navigation';
 
 // TODO: Improvement: Use same schema for client and server.
 
-const formSchema = z
-  .object({
-    name: z
-      .string()
-      .trim()
-      .min(2, 'El nombre debe tener al menos 2 caracteres')
-      .max(100, 'El nombre no puede tener más de 100 caracteres')
-      .regex(
-        /^[a-zA-ZÀ-ÿ\s]+$/,
-        'El nombre solo puede contener letras (a-z, A-Z) y espacios. No se permiten números ni caracteres especiales',
-      ),
-    email: z.string().email('Correo electrónico inválido'),
-    password: z.string().min(8, 'La contraseña debe tener al menos 8 caracteres'),
-    confirmPassword: z.string(),
-  })
-  .refine((data) => data.password === data.confirmPassword, {
-    message: 'Las contraseñas no coinciden',
-    path: ['confirmPassword'],
-  });
+const formSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(2, 'El nombre debe tener al menos 2 caracteres')
+    .max(100, 'El nombre no puede tener más de 100 caracteres')
+    .regex(
+      /^[a-zA-ZÀ-ÿ\s]+$/,
+      'El nombre solo puede contener letras (a-z, A-Z) y espacios. No se permiten números ni caracteres especiales',
+    ),
+  email: z.string().email('Correo electrónico inválido'),
+  password: z.string().min(8, 'La contraseña debe tener al menos 8 caracteres'),
+});
 
 export const signUp = async (data: z.infer<typeof formSchema>) => {
   const cleanedData = formSchema.parse(data);

--- a/src/actions/auth/sign-up.ts
+++ b/src/actions/auth/sign-up.ts
@@ -5,25 +5,12 @@ import { z } from 'zod';
 import bcrypt from 'bcryptjs';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
+import { signUpSchema } from '@/lib/validations/auth-schemas';
 
-// TODO: Improvement: Use same schema for client and server.
-
-const formSchema = z.object({
-  name: z
-    .string()
-    .trim()
-    .min(2, 'El nombre debe tener al menos 2 caracteres')
-    .max(100, 'El nombre no puede tener más de 100 caracteres')
-    .regex(
-      /^[a-zA-ZÀ-ÿ\s]+$/,
-      'El nombre solo puede contener letras (a-z, A-Z) y espacios. No se permiten números ni caracteres especiales',
-    ),
-  email: z.string().email('Correo electrónico inválido'),
-  password: z.string().min(8, 'La contraseña debe tener al menos 8 caracteres'),
-});
+const formSchema = signUpSchema;
 
 export const signUp = async (data: z.infer<typeof formSchema>) => {
-  const cleanedData = formSchema.parse(data);
+  const { confirmPassword, ...cleanedData } = formSchema.parse(data);
 
   const hashedPassword = await bcrypt.hash(cleanedData.password, 10);
 

--- a/src/app/auth/sign-up/page.tsx
+++ b/src/app/auth/sign-up/page.tsx
@@ -16,26 +16,9 @@ import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import * as z from 'zod';
 import { LogIn, UserPlus, SquareAsterisk, ArrowLeft } from 'lucide-react';
+import { signUpSchema } from '@/lib/validations/auth-schemas';
 
-const formSchema = z
-  .object({
-    name: z
-      .string()
-      .trim()
-      .min(2, 'El nombre debe tener al menos 2 caracteres')
-      .max(100, 'El nombre no puede tener más de 100 caracteres')
-      .regex(
-        /^[a-zA-ZÀ-ÿ\s]+$/,
-        'El nombre solo puede contener letras (a-z, A-Z) y espacios. No se permiten números ni caracteres especiales',
-      ),
-    email: z.string().email('Correo electrónico inválido'),
-    password: z.string().min(8, 'La contraseña debe tener al menos 8 caracteres'),
-    confirmPassword: z.string(),
-  })
-  .refine((data) => data.password === data.confirmPassword, {
-    message: 'Las contraseñas no coinciden',
-    path: ['confirmPassword'],
-  });
+const formSchema = signUpSchema;
 
 export default function SignUpPage() {
   const form = useForm<z.infer<typeof formSchema>>({

--- a/src/lib/validations/auth-schemas.ts
+++ b/src/lib/validations/auth-schemas.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export const signUpSchema = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(2, 'El nombre debe tener al menos 2 caracteres')
+      .max(100, 'El nombre no puede tener más de 100 caracteres')
+      .regex(
+        /^[a-zA-ZÀ-ÿ\s]+$/,
+        'El nombre solo puede contener letras (a-z, A-Z) y espacios. No se permiten números ni caracteres especiales',
+      ),
+    email: z.string().email('Correo electrónico inválido'),
+    password: z.string().min(8, 'La contraseña debe tener al menos 8 caracteres'),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: 'Las contraseñas no coinciden',
+    path: ['confirmPassword'],
+  });
+
+// Podemos agregar más esquemas relacionados aquí
+// Por ejemplo:
+// export const signInSchema = z.object({ ... });
+// export const resetPasswordSchema = z.object({ ... });

--- a/src/lib/validations/auth-schemas.ts
+++ b/src/lib/validations/auth-schemas.ts
@@ -12,7 +12,10 @@ export const signUpSchema = z
         'El nombre solo puede contener letras (a-z, A-Z) y espacios. No se permiten números ni caracteres especiales',
       ),
     email: z.string().email('Correo electrónico inválido'),
-    password: z.string().min(8, 'La contraseña debe tener al menos 8 caracteres'),
+    password: z
+      .string()
+      .min(1, 'Campo obligatorio')
+      .min(8, 'La contraseña debe tener al menos 8 caracteres'),
     confirmPassword: z.string(),
   })
   .refine((data) => data.password === data.confirmPassword, {


### PR DESCRIPTION
Solución al Issue #148 

## 🔧 Características agregadas
* Se agregó una validación para cuando el campo de contraseña está vacío al crear una cuenta. Ahora se muestra el mensaje: "Campo obligatorio"

## 📂 Archivos relevantes

Archivo| Descripción
-- | --
src/lib/validations/auth-schemas.ts | Schema de validación del formulario de sign up.

 ## 📹Video
https://github.com/user-attachments/assets/4e448484-4061-4f86-a3d7-36a2ab05be26

