### PR TITLE
[PCN-148] Crear un notificador para discord cuando una rama se mergee a testing

### DIFF
--- a/.github/workflows/notify-on-merge-testing-branch.yml
+++ b/.github/workflows/notify-on-merge-testing-branch.yml
@@ -1,0 +1,17 @@
+name: Notificar en Discord cuando se haga merge a testing
+
+on:
+  push:
+    branches:
+      - testing
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notificar merge en branch testing en Discord
+        run: |
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               -d "{\"content\": \"✅ Se hizo *merge* a la rama \`testing\` por ${{ github.actor }} 🚀\"}" \
+               ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
Solución al Issue #168 

## 🔧 Características agregadas
* Se agregó una GitHub action para enviar notificaciones al canal de Discord de nombre GitHub cada vez que una rama sea mergeada a `testing` 

## 📂 Archivos relevantes

Archivo| Descripción
-- | --
.github/workflows/notify-on-merge-testing-branch.yml | GitHub Action del Notificador