### PR TITLE
[PCN - #103] - Corregir posición del titulo Galeria de fotos

### DIFF
--- a/src/app/(platform)/galeria/page.tsx
+++ b/src/app/(platform)/galeria/page.tsx
@@ -20,12 +20,10 @@ export default function PhotoGallery() {
   }, [photoId]);
 
   return (
-    <div className="min-h-screen">
-      <header className="py-6">
-        <div className="container mx-auto">
+    <div className="mt-4 md:px-20">
+        <div className="mb-8 flex w-full flex-row items-center justify-between">
           <Heading2 className="text-center">Galería de fotos</Heading2>
         </div>
-      </header>
 
       <main className="container mx-auto px-4 py-8">
         <Gallery initialPhotoId={initialPhotoId} />

--- a/src/components/photo-gallery/gallery.tsx
+++ b/src/components/photo-gallery/gallery.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { dateContainsString } from '@/lib/date-formatter';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 import { PhotoCard } from './photo-card';
 import { PhotoDialog } from './photo-dialog';
@@ -96,7 +96,6 @@ interface GalleryProps {
 
 export function Gallery({ initialPhotoId }: GalleryProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const [selectedPhotoIndex, setSelectedPhotoIndex] = useState<number>(-1);
   const [searchQuery, setSearchQuery] = useState('');
   const [sortOrder, setSortOrder] = useState<SortOrder>('default');


### PR DESCRIPTION
Se desarrolla solución para el issue #103, la cual corrige el posicionamiento del titulo "Galería de fotos" para que coincida con el formato estandar:

Problema:

![image](https://github.com/user-attachments/assets/5de05c13-17ff-4ba1-b04e-955689370e0e)

Solución:

![image](https://github.com/user-attachments/assets/3e442908-661c-49d6-a98f-c63b5f51463b)