### PR TITLE
Feat/event waitlist auto promotion

### DIFF
--- a/prisma/migrations/20260410120000_add_event_waitlist/migration.sql
+++ b/prisma/migrations/20260410120000_add_event_waitlist/migration.sql
@@ -1,0 +1,33 @@
+-- CreateTable
+CREATE TABLE "EventWaitlistEntry" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "cancelledAt" TIMESTAMP(3),
+    "promotedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "EventWaitlistEntry_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "EventWaitlistEntry_eventId_idx" ON "EventWaitlistEntry"("eventId");
+
+-- CreateIndex
+CREATE INDEX "EventWaitlistEntry_userId_idx" ON "EventWaitlistEntry"("userId");
+
+-- CreateIndex
+CREATE INDEX "EventWaitlistEntry_cancelledAt_idx" ON "EventWaitlistEntry"("cancelledAt");
+
+-- CreateIndex
+CREATE INDEX "EventWaitlistEntry_promotedAt_idx" ON "EventWaitlistEntry"("promotedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "EventWaitlistEntry_eventId_userId_key" ON "EventWaitlistEntry"("eventId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "EventWaitlistEntry" ADD CONSTRAINT "EventWaitlistEntry_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "Event"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EventWaitlistEntry" ADD CONSTRAINT "EventWaitlistEntry_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,6 +38,7 @@ model User {
   comments        Comment[]
   likes           Like[]
   eventRegistrations EventRegistration[]
+  eventWaitlistEntries EventWaitlistEntry[]
   pageVisits      PageVisit[]
   testimonials    Testimonial[]
   notifications   Notification[]
@@ -125,6 +126,7 @@ model Event {
 
   images        Image[]
   registrations EventRegistration[]
+  waitlistEntries EventWaitlistEntry[]
   sponsors      Sponsor[]
   announcements Announcement[]
 }
@@ -200,6 +202,25 @@ model EventRegistration {
   @@index([eventId])
   @@index([userId])
   @@index([cancelledAt])
+}
+
+model EventWaitlistEntry {
+  id          String    @id @default(cuid())
+  eventId     String
+  userId      String
+  cancelledAt DateTime?
+  promotedAt  DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  event       Event     @relation(fields: [eventId], references: [id], onDelete: Cascade)
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([eventId, userId])
+  @@index([eventId])
+  @@index([userId])
+  @@index([cancelledAt])
+  @@index([promotedAt])
 }
 
 model Sponsor {

--- a/src/actions/events/cancel-registration.ts
+++ b/src/actions/events/cancel-registration.ts
@@ -4,6 +4,7 @@ import prisma from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 import { notifyAdmins } from '@/actions/notifications/notify-admins';
+import { promoteNextFromWaitlist } from '@/actions/events/event-capacity';
 
 type CancelRegistrationParams = {
   registrationId?: string;
@@ -41,6 +42,7 @@ export const cancelRegistration = async (params: CancelRegistrationParams) => {
   }
 
   let registration = null;
+  let waitlistEntry = null;
 
   // Si hay registrationId, verificar que pertenece al usuario
   if (registrationId) {
@@ -66,34 +68,90 @@ export const cancelRegistration = async (params: CancelRegistrationParams) => {
   }
 
   if (!registration) {
-    throw new Error('Inscripción no encontrada o ya cancelada');
+    waitlistEntry = await prisma.eventWaitlistEntry.findFirst({
+      where: {
+        eventId: eventId,
+        userId: session.userId,
+        cancelledAt: null,
+        promotedAt: null,
+      },
+      include: {
+        user: true,
+      },
+    });
   }
 
-  const userName = registration.user.name;
-  const userEmail = registration.user.email;
+  if (!registration && !waitlistEntry) {
+    throw new Error('No se encontró una inscripción activa ni una inscripción fuera de cupo');
+  }
 
-  // Marcar como cancelada (no eliminar)
-  await prisma.eventRegistration.update({
-    where: { id: registration.id },
-    data: {
-      cancelledAt: new Date(),
-    },
-  });
+  const targetUser = registration?.user || waitlistEntry?.user;
+  const userName = targetUser?.name || session.user.name;
+  const userEmail = targetUser?.email || session.user.email;
 
-  // Notificar a los admins sobre la cancelación
-  await notifyAdmins({
-    type: 'event_registration_cancelled',
-    title: 'Inscripción cancelada',
-    message: `${userName} ha cancelado su inscripción al evento "${event.name}"`,
-    metadata: {
-      eventId: eventId,
-      eventName: event.name,
-      registrationId: registration.id,
-      userName: userName,
-      userEmail: userEmail,
-    },
-  });
+  if (registration) {
+    await prisma.eventRegistration.update({
+      where: { id: registration.id },
+      data: {
+        cancelledAt: new Date(),
+      },
+    });
+
+    const promoted = await promoteNextFromWaitlist(eventId);
+    if (promoted) {
+      await notifyAdmins({
+        type: 'event_waitlist_promoted',
+        title: 'Promoción automática desde lista de espera',
+        message: `${promoted.userName} obtuvo un cupo en "${event.name}"`,
+        metadata: {
+          eventId,
+          eventName: event.name,
+          registrationId: promoted.registrationId,
+          userId: promoted.userId,
+          userName: promoted.userName,
+          userEmail: promoted.userEmail,
+        },
+      });
+    }
+  }
+
+  if (waitlistEntry) {
+    await prisma.eventWaitlistEntry.update({
+      where: { id: waitlistEntry.id },
+      data: {
+        cancelledAt: new Date(),
+      },
+    });
+  }
+
+  await notifyAdmins(
+    registration
+      ? {
+          type: 'event_registration_cancelled',
+          title: 'Inscripción cancelada',
+          message: `${userName} ha cancelado su inscripción al evento "${event.name}"`,
+          metadata: {
+            eventId: eventId,
+            eventName: event.name,
+            registrationId: registration.id,
+            userName: userName,
+            userEmail: userEmail,
+          },
+        }
+      : {
+          type: 'event_waitlist_cancelled',
+          title: 'Salida de lista de espera',
+          message: `${userName} salió de la lista de espera del evento "${event.name}"`,
+          metadata: {
+            eventId: eventId,
+            eventName: event.name,
+            waitlistId: waitlistEntry!.id,
+            userName: userName,
+            userEmail: userEmail,
+          },
+        },
+  );
 
   revalidatePath(`/eventos/${eventId}`);
-  return { success: true };
+  return { success: true, status: registration ? 'cancelled_registration' : 'cancelled_waitlist' };
 };

--- a/src/actions/events/check-event-capacity.ts
+++ b/src/actions/events/check-event-capacity.ts
@@ -1,39 +1,27 @@
 'use server';
 
-import prisma from '@/lib/prisma';
+import { getCapacitySnapshot } from '@/actions/events/event-capacity';
 
 export const checkEventCapacity = async (eventId: string) => {
-  const event = await prisma.event.findFirst({
-    where: {
-      id: eventId,
-      deletedAt: null,
-    },
-  });
+  const snapshot = await getCapacitySnapshot(eventId);
 
-  if (!event) {
+  if (!snapshot) {
     return { available: false, message: 'Evento no encontrado' };
   }
 
-  // Si no tiene cupo definido, está disponible
-  if (event.capacity === null) {
-    return { available: true, current: 0, capacity: null };
+  if (snapshot.capacity === null) {
+    return { available: true, current: snapshot.current, capacity: null, waitlistCount: 0 };
   }
 
-  const currentRegistrations = await prisma.eventRegistration.count({
-    where: {
-      eventId: eventId,
-      cancelledAt: null, // Excluir inscripciones canceladas
-    },
-  });
-
-  const available = currentRegistrations < event.capacity;
+  const available = snapshot.available;
 
   return {
     available,
-    current: currentRegistrations,
-    capacity: event.capacity,
+    current: snapshot.current,
+    capacity: snapshot.capacity,
+    waitlistCount: snapshot.waitlistCount,
     message: available
-      ? `Quedan ${event.capacity - currentRegistrations} lugares disponibles.`
-      : 'El cupo del evento está completo',
+      ? `Quedan ${snapshot.capacity - snapshot.current} lugares disponibles.`
+      : 'El cupo del evento está completo. Podés sumarte a la lista de espera.',
   };
 };

--- a/src/actions/events/delete-registration.ts
+++ b/src/actions/events/delete-registration.ts
@@ -3,6 +3,8 @@
 import prisma from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
+import { promoteNextFromWaitlist } from '@/actions/events/event-capacity';
+import { notifyAdmins } from '@/actions/notifications/notify-admins';
 
 export const deleteRegistration = async (registrationId: string) => {
   // Verificar que el usuario es admin
@@ -33,6 +35,28 @@ export const deleteRegistration = async (registrationId: string) => {
   await prisma.eventRegistration.delete({
     where: { id: registrationId },
   });
+
+  const event = await prisma.event.findUnique({
+    where: { id: registration.eventId },
+    select: { name: true },
+  });
+
+  const promoted = await promoteNextFromWaitlist(registration.eventId);
+  if (promoted && event) {
+    await notifyAdmins({
+      type: 'event_waitlist_promoted',
+      title: 'Promoción automática desde lista de espera',
+      message: `${promoted.userName} obtuvo un cupo en "${event.name}"`,
+      metadata: {
+        eventId: registration.eventId,
+        eventName: event.name,
+        registrationId: promoted.registrationId,
+        userId: promoted.userId,
+        userName: promoted.userName,
+        userEmail: promoted.userEmail,
+      },
+    });
+  }
 
   revalidatePath(`/eventos/${registration.eventId}`);
   return { success: true };

--- a/src/actions/events/event-capacity.ts
+++ b/src/actions/events/event-capacity.ts
@@ -1,0 +1,184 @@
+'use server';
+
+import { Prisma } from '@prisma/client';
+import prisma from '@/lib/prisma';
+
+type CapacitySnapshot = {
+  capacity: number | null;
+  current: number;
+  available: boolean;
+  waitlistCount: number;
+};
+
+const getActiveRegistrationsCount = (tx: Prisma.TransactionClient, eventId: string) =>
+  tx.eventRegistration.count({
+    where: {
+      eventId,
+      cancelledAt: null,
+    },
+  });
+
+const getActiveWaitlistCount = (tx: Prisma.TransactionClient, eventId: string) =>
+  tx.eventWaitlistEntry.count({
+    where: {
+      eventId,
+      cancelledAt: null,
+      promotedAt: null,
+    },
+  });
+
+export const getCapacitySnapshot = async (eventId: string): Promise<CapacitySnapshot | null> => {
+  return prisma.$transaction(async (tx) => {
+    const event = await tx.event.findFirst({
+      where: {
+        id: eventId,
+        deletedAt: null,
+      },
+      select: {
+        capacity: true,
+      },
+    });
+
+    if (!event) {
+      return null;
+    }
+
+    const [current, waitlistCount] = await Promise.all([
+      getActiveRegistrationsCount(tx, eventId),
+      getActiveWaitlistCount(tx, eventId),
+    ]);
+
+    return {
+      capacity: event.capacity,
+      current,
+      available: event.capacity === null ? true : current < event.capacity,
+      waitlistCount,
+    };
+  });
+};
+
+export const getWaitlistPosition = async (eventId: string, userId: string): Promise<number | null> => {
+  const waitlistEntries = await prisma.eventWaitlistEntry.findMany({
+    where: {
+      eventId,
+      cancelledAt: null,
+      promotedAt: null,
+    },
+    orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+    select: {
+      userId: true,
+    },
+  });
+
+  const position = waitlistEntries.findIndex((entry) => entry.userId === userId);
+  return position === -1 ? null : position + 1;
+};
+
+export const promoteNextFromWaitlist = async (eventId: string) => {
+  return prisma.$transaction(
+    async (tx) => {
+      const event = await tx.event.findFirst({
+        where: {
+          id: eventId,
+          deletedAt: null,
+        },
+        select: {
+          id: true,
+          capacity: true,
+        },
+      });
+
+      if (!event) {
+        return null;
+      }
+
+      const currentRegistrations = await getActiveRegistrationsCount(tx, eventId);
+      if (event.capacity !== null && currentRegistrations >= event.capacity) {
+        return null;
+      }
+
+      const nextWaitlistEntry = await tx.eventWaitlistEntry.findFirst({
+        where: {
+          eventId,
+          cancelledAt: null,
+          promotedAt: null,
+        },
+        include: {
+          user: {
+            select: {
+              id: true,
+              name: true,
+              email: true,
+            },
+          },
+        },
+        orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
+      });
+
+      if (!nextWaitlistEntry) {
+        return null;
+      }
+
+      const existingRegistration = await tx.eventRegistration.findFirst({
+        where: {
+          eventId,
+          userId: nextWaitlistEntry.userId,
+        },
+      });
+
+      let registrationId: string;
+      if (existingRegistration && existingRegistration.cancelledAt === null) {
+        await tx.eventWaitlistEntry.update({
+          where: { id: nextWaitlistEntry.id },
+          data: {
+            cancelledAt: new Date(),
+          },
+        });
+        return null;
+      }
+
+      if (existingRegistration) {
+        const reactivated = await tx.eventRegistration.update({
+          where: { id: existingRegistration.id },
+          data: {
+            cancelledAt: null,
+          },
+          select: {
+            id: true,
+          },
+        });
+        registrationId = reactivated.id;
+      } else {
+        const created = await tx.eventRegistration.create({
+          data: {
+            eventId,
+            userId: nextWaitlistEntry.userId,
+          },
+          select: {
+            id: true,
+          },
+        });
+        registrationId = created.id;
+      }
+
+      await tx.eventWaitlistEntry.update({
+        where: {
+          id: nextWaitlistEntry.id,
+        },
+        data: {
+          promotedAt: new Date(),
+        },
+      });
+
+      return {
+        registrationId,
+        userId: nextWaitlistEntry.user.id,
+        userName: nextWaitlistEntry.user.name,
+        userEmail: nextWaitlistEntry.user.email,
+      };
+    },
+    {
+      isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+    },
+  );
+};

--- a/src/actions/events/register-event.ts
+++ b/src/actions/events/register-event.ts
@@ -1,24 +1,29 @@
 'use server';
 
+import { Prisma } from '@prisma/client';
 import prisma from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { notifyAdmins } from '@/actions/notifications/notify-admins';
 
-export const registerEvent = async (eventId: string, options?: { skipRedirect?: boolean }) => {
-  // Verificar que el evento existe y no está eliminado
-  const event = await prisma.event.findFirst({
-    where: {
-      id: eventId,
-      deletedAt: null,
-    },
-  });
+type RegistrationResult =
+  | {
+      success: true;
+      status: 'registered';
+      registrationId: string;
+    }
+  | {
+      success: true;
+      status: 'waitlisted';
+      waitlistId: string;
+      position: number;
+    };
 
-  if (!event) {
-    throw new Error('Evento no encontrado');
-  }
-
+export const registerEvent = async (
+  eventId: string,
+  options?: { skipRedirect?: boolean },
+): Promise<RegistrationResult> => {
   // Requerir autenticación - solo usuarios autenticados pueden inscribirse
   const sessionId = cookies().get('sessionId')?.value;
   if (!sessionId) {
@@ -38,97 +43,201 @@ export const registerEvent = async (eventId: string, options?: { skipRedirect?: 
   const userName = session.user.name;
   const userEmail = session.user.email;
 
-  // Verificar si ya existe una inscripción (activa o cancelada)
-  const existingRegistration = await prisma.eventRegistration.findFirst({
-    where: {
-      eventId: eventId,
-      userId: userId,
-    },
-  });
-
-  // Si existe una inscripción activa, no permitir
-  if (existingRegistration && existingRegistration.cancelledAt === null) {
-    throw new Error('Ya estás registrado en este evento');
-  }
-
-  // Validar cupo disponible (verificar nuevamente antes de crear/actualizar la inscripción)
-  if (event.capacity !== null) {
-    const currentRegistrations = await prisma.eventRegistration.count({
-      where: {
-        eventId: eventId,
-        cancelledAt: null, // Excluir inscripciones canceladas
-      },
-    });
-
-    if (currentRegistrations >= event.capacity) {
-      throw new Error('El cupo del evento está completo. No se pueden aceptar más inscripciones.');
-    }
-  }
-
-  let registrationId: string;
   try {
-    // Si existe una inscripción cancelada, reactivarla
-    if (existingRegistration && existingRegistration.cancelledAt !== null) {
-      await prisma.eventRegistration.update({
-        where: { id: existingRegistration.id },
-        data: {
-          cancelledAt: null, // Reactivar la inscripción
+    const result = await prisma.$transaction(
+      async (tx) => {
+        const event = await tx.event.findFirst({
+          where: {
+            id: eventId,
+            deletedAt: null,
+          },
+          select: {
+            id: true,
+            name: true,
+            capacity: true,
+          },
+        });
+
+        if (!event) {
+          throw new Error('Evento no encontrado');
+        }
+
+        const [existingRegistration, existingWaitlist] = await Promise.all([
+          tx.eventRegistration.findFirst({
+            where: {
+              eventId,
+              userId,
+            },
+          }),
+          tx.eventWaitlistEntry.findFirst({
+            where: {
+              eventId,
+              userId,
+            },
+          }),
+        ]);
+
+        if (existingRegistration && existingRegistration.cancelledAt === null) {
+          throw new Error('Ya estás registrado en este evento');
+        }
+
+        const currentRegistrations = await tx.eventRegistration.count({
+          where: {
+            eventId,
+            cancelledAt: null,
+          },
+        });
+
+        const hasCapacity = event.capacity === null || currentRegistrations < event.capacity;
+
+        if (hasCapacity) {
+          let registrationId: string;
+          if (existingRegistration) {
+            const registration = await tx.eventRegistration.update({
+              where: { id: existingRegistration.id },
+              data: { cancelledAt: null },
+              select: { id: true },
+            });
+            registrationId = registration.id;
+          } else {
+            const registration = await tx.eventRegistration.create({
+              data: {
+                eventId,
+                userId,
+              },
+              select: { id: true },
+            });
+            registrationId = registration.id;
+          }
+
+          if (existingWaitlist && existingWaitlist.cancelledAt === null && !existingWaitlist.promotedAt) {
+            await tx.eventWaitlistEntry.update({
+              where: { id: existingWaitlist.id },
+              data: {
+                cancelledAt: new Date(),
+              },
+            });
+          }
+
+          return {
+            eventName: event.name,
+            result: {
+              success: true,
+              status: 'registered',
+              registrationId,
+            } as RegistrationResult,
+          };
+        }
+
+        if (existingWaitlist && existingWaitlist.cancelledAt === null && !existingWaitlist.promotedAt) {
+          throw new Error('Ya estás en la lista de espera de este evento');
+        }
+
+        let waitlistId: string;
+        let waitlistCreatedAt: Date;
+        if (existingWaitlist) {
+          const reactivatedWaitlist = await tx.eventWaitlistEntry.update({
+            where: { id: existingWaitlist.id },
+            data: {
+              cancelledAt: null,
+              promotedAt: null,
+              createdAt: new Date(),
+            },
+            select: {
+              id: true,
+              createdAt: true,
+            },
+          });
+          waitlistId = reactivatedWaitlist.id;
+          waitlistCreatedAt = reactivatedWaitlist.createdAt;
+        } else {
+          const createdWaitlist = await tx.eventWaitlistEntry.create({
+            data: {
+              eventId,
+              userId,
+            },
+            select: {
+              id: true,
+              createdAt: true,
+            },
+          });
+          waitlistId = createdWaitlist.id;
+          waitlistCreatedAt = createdWaitlist.createdAt;
+        }
+
+        const position = await tx.eventWaitlistEntry.count({
+          where: {
+            eventId,
+            cancelledAt: null,
+            promotedAt: null,
+            createdAt: {
+              lte: waitlistCreatedAt,
+            },
+          },
+        });
+
+        return {
+          eventName: event.name,
+          result: {
+            success: true,
+            status: 'waitlisted',
+            waitlistId,
+            position,
+          } as RegistrationResult,
+        };
+      },
+      {
+        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+      },
+    );
+
+    if (result.result.status === 'registered') {
+      await notifyAdmins({
+        type: 'event_registration_created',
+        title: 'Nueva inscripción a evento',
+        message: `${userName} se ha inscrito al evento "${result.eventName}"`,
+        metadata: {
+          eventId,
+          eventName: result.eventName,
+          registrationId: result.result.registrationId,
+          userName,
+          userEmail,
         },
       });
-      registrationId = existingRegistration.id;
     } else {
-      // Crear nueva inscripción
-      const newRegistration = await prisma.eventRegistration.create({
-        data: {
-          eventId: eventId,
-          userId: userId,
+      await notifyAdmins({
+        type: 'event_waitlist_joined',
+        title: 'Nueva inscripción fuera de cupo',
+        message: `${userName} se sumó a la lista de espera del evento "${result.eventName}"`,
+        metadata: {
+          eventId,
+          eventName: result.eventName,
+          waitlistId: result.result.waitlistId,
+          waitlistPosition: result.result.position,
+          userName,
+          userEmail,
         },
       });
-      registrationId = newRegistration.id;
     }
 
-    // Notificar a los admins sobre la nueva inscripción
-    await notifyAdmins({
-      type: 'event_registration_created',
-      title: 'Nueva inscripción a evento',
-      message: `${userName} se ha inscrito al evento "${event.name}"`,
-      metadata: {
-        eventId: eventId,
-        eventName: event.name,
-        registrationId: registrationId,
-        userName: userName,
-        userEmail: userEmail,
-      },
-    });
-  } catch (error: any) {
-    // Manejar error de constraint único de Prisma (caso de condición de carrera)
-    if (error.code === 'P2002' && error.meta?.target?.includes('userId')) {
-      // Verificar nuevamente si existe una inscripción activa
-      const duplicateCheck = await prisma.eventRegistration.findFirst({
-        where: {
-          eventId: eventId,
-          userId: userId,
-          cancelledAt: null,
-        },
-      });
+    revalidatePath(`/eventos/${eventId}`);
 
-      if (duplicateCheck) {
-        throw new Error('Ya estás registrado en este evento');
-      }
-      // Si no hay inscripción activa, podría ser un error de timing, reintentar
-      throw new Error(
-        'Ocurrió un error al procesar la inscripción. Por favor, intenta nuevamente.',
-      );
+    if (options?.skipRedirect) {
+      return result.result;
+    }
+
+    if (result.result.status === 'waitlisted') {
+      redirect(`/eventos/${eventId}?waitlisted=true`);
+    }
+
+    redirect(`/eventos/${eventId}?registered=true`);
+  } catch (error: any) {
+    if (error.code === 'P2002') {
+      throw new Error('Ya estás inscripto para este evento o en su lista de espera');
+    }
+    if (error.code === 'P2034') {
+      throw new Error('Se detectó mucha actividad en simultáneo. Intentá nuevamente.');
     }
     throw error;
   }
-
-  revalidatePath(`/eventos/${eventId}`);
-
-  // Si skipRedirect es true, no redirigir (útil para inscripción automática desde el botón)
-  if (options?.skipRedirect) {
-    return { success: true, registrationId };
-  }
-
-  redirect(`/eventos/${eventId}?registered=true`);
 };

--- a/src/app/(platform)/eventos/[id]/inscripciones/page.tsx
+++ b/src/app/(platform)/eventos/[id]/inscripciones/page.tsx
@@ -66,21 +66,36 @@ const EventRegistrationsPage = async ({ params }: { params: { id: string } }) =>
     redirect('/eventos');
   }
 
-  // Obtener todas las inscripciones con datos del usuario
-  const registrations = await prisma.eventRegistration.findMany({
-    where: {
-      eventId: id,
-    },
-    include: {
-      user: true,
-    },
-    orderBy: {
-      createdAt: 'desc',
-    },
-  });
+  const [registrations, waitlistEntries] = await Promise.all([
+    prisma.eventRegistration.findMany({
+      where: {
+        eventId: id,
+      },
+      include: {
+        user: true,
+      },
+      orderBy: {
+        createdAt: 'desc',
+      },
+    }),
+    prisma.eventWaitlistEntry.findMany({
+      where: {
+        eventId: id,
+      },
+      include: {
+        user: true,
+      },
+      orderBy: {
+        createdAt: 'asc',
+      },
+    }),
+  ]);
 
   const activeRegistrations = registrations.filter((r) => r.cancelledAt === null);
   const cancelledRegistrations = registrations.filter((r) => r.cancelledAt !== null);
+  const activeWaitlistEntries = waitlistEntries.filter(
+    (entry) => entry.cancelledAt === null && entry.promotedAt === null,
+  );
 
   return (
     <>
@@ -127,7 +142,7 @@ const EventRegistrationsPage = async ({ params }: { params: { id: string } }) =>
               <CardTitle className="flex items-center gap-2">
                 <Users className="h-5 w-5" />
                 Inscripciones ({registrations.length} total - {activeRegistrations.length} activas,{' '}
-                {cancelledRegistrations.length} canceladas)
+                {cancelledRegistrations.length} canceladas, {activeWaitlistEntries.length} fuera de cupo)
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -213,6 +228,47 @@ const EventRegistrationsPage = async ({ params }: { params: { id: string } }) =>
                           </TableRow>
                         );
                       })}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card className="mt-5 border-2 border-transparent bg-gradient-to-br from-white to-gray-50 transition-all duration-300 hover:border-pcnPurple hover:shadow-xl dark:border-neutral-800 dark:from-neutral-900 dark:to-neutral-800 dark:hover:border-pcnGreen dark:hover:shadow-pcnGreen/20">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Users className="h-5 w-5" />
+                Lista de espera ({activeWaitlistEntries.length} activas)
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {activeWaitlistEntries.length === 0 ? (
+                <p className="py-4 text-sm text-muted-foreground">
+                  No hay personas en lista de espera para este evento.
+                </p>
+              ) : (
+                <div className="rounded-md border">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Posición</TableHead>
+                        <TableHead>Nombre</TableHead>
+                        <TableHead>Email</TableHead>
+                        <TableHead>Ingreso a lista</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {activeWaitlistEntries.map((entry, index) => (
+                        <TableRow key={entry.id}>
+                          <TableCell className="font-medium">#{index + 1}</TableCell>
+                          <TableCell>{entry.user.name}</TableCell>
+                          <TableCell>{entry.user.email}</TableCell>
+                          <TableCell className="text-sm text-muted-foreground">
+                            {formatDate(entry.createdAt)}
+                          </TableCell>
+                        </TableRow>
+                      ))}
                     </TableBody>
                   </Table>
                 </div>

--- a/src/app/(platform)/eventos/[id]/page.tsx
+++ b/src/app/(platform)/eventos/[id]/page.tsx
@@ -229,7 +229,7 @@ const EventDetailPage: React.FC<{ params: { id: string } }> = async ({ params })
           <Breadcrumb>
             <BreadcrumbList>
               <BreadcrumbItem className="hidden md:block">
-                <BreadcrumbLink href="/home">Inicio</BreadcrumbLink>
+                <BreadcrumbLink href="/">Inicio</BreadcrumbLink>
               </BreadcrumbItem>
               <BreadcrumbSeparator className="hidden md:block" />
               <BreadcrumbItem className="hidden md:block">

--- a/src/app/(platform)/eventos/[id]/page.tsx
+++ b/src/app/(platform)/eventos/[id]/page.tsx
@@ -372,7 +372,6 @@ const EventDetailPage: React.FC<{ params: { id: string } }> = async ({ params })
                       <p className="text-sm font-medium">Fecha y hora</p>
                       <p className="text-sm text-muted-foreground">
                         {formatDate(event.date)} a las {formatTime(event.date)}
-                        {event.endDate && ` - ${formatTime(event.endDate)}`}
                       </p>
                     </div>
                   </div>

--- a/src/app/(platform)/eventos/[id]/page.tsx
+++ b/src/app/(platform)/eventos/[id]/page.tsx
@@ -25,6 +25,7 @@ import Link from 'next/link';
 import prisma from '@/lib/prisma';
 import { cookies } from 'next/headers';
 import type { Metadata } from 'next';
+import { getWaitlistPosition } from '@/actions/events/event-capacity';
 
 type EventWithImages = Event & {
   images: Images[];
@@ -153,36 +154,63 @@ const EventDetailPage: React.FC<{ params: { id: string } }> = async ({ params })
   const eventEndDate = event.endDate || event.date;
   const hasEventPassed = new Date(eventEndDate) < now;
 
-  // Verificar si el usuario ya está registrado (solo inscripciones activas)
+  // Verificar si el usuario está confirmado o fuera de cupo
   let isRegistered = false;
+  let isWaitlisted = false;
+  let waitlistPosition: number | null = null;
   let registrationId: string | null = null;
   if (userId) {
-    const registration = await prisma.eventRegistration.findFirst({
-      where: {
-        eventId: id,
-        userId: userId,
-        cancelledAt: null, // Solo considerar inscripciones activas
-      },
-    });
+    const [registration, waitlistEntry] = await Promise.all([
+      prisma.eventRegistration.findFirst({
+        where: {
+          eventId: id,
+          userId: userId,
+          cancelledAt: null,
+        },
+      }),
+      prisma.eventWaitlistEntry.findFirst({
+        where: {
+          eventId: id,
+          userId: userId,
+          cancelledAt: null,
+          promotedAt: null,
+        },
+      }),
+    ]);
+
     if (registration) {
       isRegistered = true;
       registrationId = registration.id;
     }
+    if (waitlistEntry) {
+      isWaitlisted = true;
+      waitlistPosition = await getWaitlistPosition(id, userId);
+    }
   }
 
-  // Obtener información del cupo
+  // Obtener información del cupo y demanda fuera de cupo
   let capacityInfo = null;
   if (event.capacity !== null) {
-    const currentRegistrations = await prisma.eventRegistration.count({
-      where: {
-        eventId: id,
-        cancelledAt: null, // Excluir inscripciones canceladas
-      },
-    });
+    const [currentRegistrations, waitlistCount] = await Promise.all([
+      prisma.eventRegistration.count({
+        where: {
+          eventId: id,
+          cancelledAt: null,
+        },
+      }),
+      prisma.eventWaitlistEntry.count({
+        where: {
+          eventId: id,
+          cancelledAt: null,
+          promotedAt: null,
+        },
+      }),
+    ]);
     capacityInfo = {
       current: currentRegistrations,
       capacity: event.capacity,
       available: currentRegistrations < event.capacity,
+      waitlistCount,
     };
   }
 
@@ -198,23 +226,36 @@ const EventDetailPage: React.FC<{ params: { id: string } }> = async ({ params })
     };
   }> = [];
 
+  let activeWaitlistCount = 0;
+
   if (isAdmin) {
-    registrations = await prisma.eventRegistration.findMany({
-      where: {
-        eventId: id,
-      },
-      include: {
-        user: {
-          select: {
-            name: true,
-            email: true,
+    const [eventRegistrations, waitlistCount] = await Promise.all([
+      prisma.eventRegistration.findMany({
+        where: {
+          eventId: id,
+        },
+        include: {
+          user: {
+            select: {
+              name: true,
+              email: true,
+            },
           },
         },
-      },
-      orderBy: {
-        createdAt: 'desc',
-      },
-    });
+        orderBy: {
+          createdAt: 'desc',
+        },
+      }),
+      prisma.eventWaitlistEntry.count({
+        where: {
+          eventId: id,
+          cancelledAt: null,
+          promotedAt: null,
+        },
+      }),
+    ]);
+    registrations = eventRegistrations;
+    activeWaitlistCount = waitlistCount;
   }
 
   // Obtener anuncios del evento
@@ -314,6 +355,9 @@ const EventDetailPage: React.FC<{ params: { id: string } }> = async ({ params })
                           activas
                         </p>
                         <p className="text-xs text-muted-foreground">
+                          {activeWaitlistCount} fuera de cupo en lista de espera
+                        </p>
+                        <p className="text-xs text-muted-foreground">
                           {registrations.length} total (incluyendo canceladas)
                         </p>
                       </div>
@@ -346,6 +390,8 @@ const EventDetailPage: React.FC<{ params: { id: string } }> = async ({ params })
                         eventName={event.name}
                         isAuthenticated={!!sessionId}
                         isRegistered={isRegistered}
+                        isWaitlisted={isWaitlisted}
+                        waitlistPosition={waitlistPosition}
                         registrationId={registrationId}
                         capacityAvailable={capacityInfo?.available ?? true}
                         capacityInfo={capacityInfo}

--- a/src/app/(platform)/testimonios/[id]/page.tsx
+++ b/src/app/(platform)/testimonios/[id]/page.tsx
@@ -36,9 +36,7 @@ export async function generateMetadata({ params }: { params: { id: string } }): 
 
   const title = `Testimonio de ${testimonial.user.name} (PCN)`;
   const description =
-    testimonial.body.length > 160
-      ? testimonial.body.substring(0, 157) + '...'
-      : testimonial.body;
+    testimonial.body.length > 160 ? testimonial.body.substring(0, 157) + '...' : testimonial.body;
   const pageUrl = `${SITE_URL}/testimonios/${params.id}`;
 
   return {

--- a/src/app/meetup/page.tsx
+++ b/src/app/meetup/page.tsx
@@ -65,7 +65,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const absoluteImageUrl = imageUrl.startsWith('http') ? imageUrl : `${SITE_URL}${imageUrl}`;
 
   return {
-    title: `${nextMeetup.name} - Meetup - PCN`,
+    title: `${nextMeetup.name} (PCN)`,
     description:
       nextMeetup.description.length > 160
         ? nextMeetup.description.substring(0, 157) + '...'
@@ -83,7 +83,7 @@ export async function generateMetadata(): Promise<Metadata> {
     },
     twitter: {
       card: 'summary_large_image',
-      title: `${nextMeetup.name} - Meetup - PCN`,
+      title: `${nextMeetup.name} (PCN)`,
       description:
         nextMeetup.description.length > 160
           ? nextMeetup.description.substring(0, 157) + '...'
@@ -134,8 +134,8 @@ const MeetupPage = async () => {
     redirect('/eventos');
   }
 
-  // Redirigir a la página de inscripción del meetup
-  redirect(`/eventos/${nextMeetup.id}/inscripcion`);
+  // Redirigir a la página de detalle del meetup
+  redirect(`/eventos/${nextMeetup.id}`);
 };
 
 export default MeetupPage;

--- a/src/components/events/cancel-registration-button.tsx
+++ b/src/components/events/cancel-registration-button.tsx
@@ -11,12 +11,14 @@ type CancelRegistrationButtonProps = {
   eventId: string;
   registrationId?: string;
   onCancel?: () => void;
+  mode?: 'registration' | 'waitlist';
 };
 
 export function CancelRegistrationButton({
   eventId,
   registrationId,
   onCancel,
+  mode = 'registration',
 }: CancelRegistrationButtonProps) {
   const [isLoading, setIsLoading] = useState(false);
   const router = useRouter();
@@ -30,8 +32,12 @@ export function CancelRegistrationButton({
           eventId,
         }),
         {
-          loading: 'Cancelando inscripción...',
-          success: 'Inscripción cancelada exitosamente',
+          loading:
+            mode === 'waitlist' ? 'Saliendo de la lista de espera...' : 'Cancelando inscripción...',
+          success:
+            mode === 'waitlist'
+              ? 'Saliste de la lista de espera exitosamente'
+              : 'Inscripción cancelada exitosamente',
           error: (error) => {
             console.error('Error al cancelar inscripción', error);
             return error.message || 'Ocurrió un error al cancelar la inscripción';
@@ -58,7 +64,7 @@ export function CancelRegistrationButton({
       disabled={isLoading}
     >
       <X className="mr-2 h-4 w-4" />
-      Cancelar inscripción
+      {mode === 'waitlist' ? 'Salir de lista de espera' : 'Cancelar inscripción'}
     </Button>
   );
 }

--- a/src/components/events/event-detail-client.tsx
+++ b/src/components/events/event-detail-client.tsx
@@ -13,12 +13,15 @@ type Props = {
   eventName: string;
   isAuthenticated: boolean;
   isRegistered: boolean;
+  isWaitlisted: boolean;
+  waitlistPosition: number | null;
   registrationId: string | null;
   capacityAvailable: boolean;
   capacityInfo: {
     current: number;
     capacity: number;
     available: boolean;
+    waitlistCount: number;
   } | null;
 };
 
@@ -27,6 +30,8 @@ export function EventDetailClient({
   eventName,
   isAuthenticated,
   isRegistered: initialIsRegistered,
+  isWaitlisted: initialIsWaitlisted,
+  waitlistPosition,
   registrationId,
   capacityAvailable,
   capacityInfo,
@@ -38,43 +43,51 @@ export function EventDetailClient({
   const [isAutoRegistering, setIsAutoRegistering] = useState(false);
   // Estado local para saber si ya se registró en esta sesión
   const [justRegisteredLocally, setJustRegisteredLocally] = useState(false);
+  const [justWaitlistedLocally, setJustWaitlistedLocally] = useState(false);
 
   const autoRegister = searchParams.get('autoRegister') === 'true';
   const justRegistered = searchParams.get('registered') === 'true';
+  const justWaitlisted = searchParams.get('waitlisted') === 'true';
 
   // El usuario está registrado si viene del server O si se registró localmente
   const isRegistered = initialIsRegistered || justRegisteredLocally;
+  const isWaitlisted = !isRegistered && (initialIsWaitlisted || justWaitlistedLocally);
 
-  // Mostrar dialog si viene con registered=true
+  // Mostrar dialog si viene con registered=true o toast si viene con waitlisted=true
   useEffect(() => {
     if (justRegistered) {
       setShowSuccessDialog(true);
       setJustRegisteredLocally(true);
+      setJustWaitlistedLocally(false);
       // Limpiar URL sin recargar
       router.replace(`/eventos/${eventId}`, { scroll: false });
     }
-  }, [justRegistered, eventId, router]);
+    if (justWaitlisted) {
+      toast.success('Te sumaste a la lista de espera de este evento.');
+      setJustWaitlistedLocally(true);
+      router.replace(`/eventos/${eventId}`, { scroll: false });
+    }
+  }, [justRegistered, justWaitlisted, eventId, router]);
 
   // Auto-registrar si viene de login/registro
   useEffect(() => {
-    if (
-      autoRegister &&
-      isAuthenticated &&
-      !isRegistered &&
-      !hasAutoRegistered &&
-      capacityAvailable
-    ) {
+    if (autoRegister && isAuthenticated && !isRegistered && !isWaitlisted && !hasAutoRegistered) {
       const performAutoRegister = async () => {
         setHasAutoRegistered(true);
         setIsAutoRegistering(true);
 
         try {
-          await registerEvent(eventId, { skipRedirect: true });
+          const result = await registerEvent(eventId, { skipRedirect: true });
 
-          // Limpiar URL y mostrar dialog
           router.replace(`/eventos/${eventId}`, { scroll: false });
-          setJustRegisteredLocally(true);
-          setShowSuccessDialog(true);
+          if (result.status === 'registered') {
+            setJustRegisteredLocally(true);
+            setShowSuccessDialog(true);
+            setJustWaitlistedLocally(false);
+          } else {
+            setJustWaitlistedLocally(true);
+            toast.success('Te sumaste a la lista de espera de este evento.');
+          }
         } catch (error: any) {
           toast.error(error.message || 'Error al inscribirse automáticamente');
           router.replace(`/eventos/${eventId}`, { scroll: false });
@@ -92,15 +105,22 @@ export function EventDetailClient({
     autoRegister,
     isAuthenticated,
     isRegistered,
+    isWaitlisted,
     hasAutoRegistered,
     eventId,
-    capacityAvailable,
     router,
   ]);
 
-  const handleRegistrationSuccess = () => {
-    setJustRegisteredLocally(true);
-    setShowSuccessDialog(true);
+  const handleRegistrationSuccess = (status: 'registered' | 'waitlisted') => {
+    if (status === 'registered') {
+      setJustRegisteredLocally(true);
+      setJustWaitlistedLocally(false);
+      setShowSuccessDialog(true);
+      return;
+    }
+
+    setJustWaitlistedLocally(true);
+    toast.success('Te sumaste a la lista de espera de este evento.');
   };
 
   const handleDialogClose = () => {
@@ -112,6 +132,7 @@ export function EventDetailClient({
   const handleCancellation = () => {
     // Resetear el estado local para mostrar el botón de inscripción
     setJustRegisteredLocally(false);
+    setJustWaitlistedLocally(false);
   };
 
   // Renderizar según el estado
@@ -139,13 +160,22 @@ export function EventDetailClient({
     );
   }
 
-  if (capacityInfo && !capacityInfo.available) {
+  if (isWaitlisted) {
     return (
-      <div className="space-y-2">
-        <p className="text-center text-sm font-medium text-destructive">Cupo completo</p>
-        <p className="text-center text-xs text-muted-foreground">
-          Ya no quedan lugares disponibles.
-        </p>
+      <div className="space-y-3">
+        <div className="space-y-2">
+          <p className="text-center text-sm font-medium">Estás en lista de espera</p>
+          <p className="text-center text-xs text-muted-foreground">
+            Te avisaremos cuando se libere un cupo.
+            {waitlistPosition ? ` Tu posición actual es #${waitlistPosition}.` : ''}
+          </p>
+        </div>
+        <CancelRegistrationButton
+          eventId={eventId}
+          registrationId={registrationId || undefined}
+          onCancel={handleCancellation}
+          mode="waitlist"
+        />
       </div>
     );
   }
@@ -162,7 +192,9 @@ export function EventDetailClient({
         />
         {capacityInfo && (
           <p className="text-center text-xs text-muted-foreground">
-            Quedan {capacityInfo.capacity - capacityInfo.current} lugares disponibles.
+            {capacityInfo.available
+              ? `Quedan ${capacityInfo.capacity - capacityInfo.current} lugares disponibles.`
+              : `Cupo completo. ${capacityInfo.waitlistCount} personas en lista de espera.`}
           </p>
         )}
       </div>

--- a/src/components/events/register-event-button.tsx
+++ b/src/components/events/register-event-button.tsx
@@ -6,13 +6,12 @@ import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { registerEvent } from '@/actions/events/register-event';
-import { checkEventCapacity } from '@/actions/events/check-event-capacity';
 
 type RegisterEventButtonProps = {
   eventId: string;
   isAuthenticated: boolean;
   capacityAvailable: boolean;
-  onSuccess?: () => void;
+  onSuccess?: (status: 'registered' | 'waitlisted') => void;
   isLoading?: boolean;
 };
 
@@ -33,32 +32,20 @@ export function RegisterEventButton({
       return;
     }
 
-    // Si no hay cupo disponible, no hacer nada
-    if (!capacityAvailable) {
-      return;
-    }
-
     setIsSubmitting(true);
 
     try {
-      // Validar cupo antes de inscribir
-      const capacityCheck = await checkEventCapacity(eventId);
-      if (!capacityCheck.available) {
-        toast.error(
-          capacityCheck.message ||
-            'El cupo del evento está completo. No se pueden aceptar más inscripciones.',
-        );
-        setIsSubmitting(false);
-        return;
-      }
-
-      await registerEvent(eventId, { skipRedirect: true });
+      const result = await registerEvent(eventId, { skipRedirect: true });
 
       // Notificar éxito
       if (onSuccess) {
-        onSuccess();
+        onSuccess(result.status);
       } else {
-        toast.success('¡Te has inscrito exitosamente al evento! 🎉');
+        if (result.status === 'registered') {
+          toast.success('¡Te has inscrito exitosamente al evento! 🎉');
+        } else {
+          toast.success('Te sumaste a la lista de espera del evento.');
+        }
         router.refresh();
       }
     } catch (error: any) {
@@ -76,10 +63,14 @@ export function RegisterEventButton({
       variant="pcn"
       className="flex w-full items-center gap-2"
       onClick={handleClick}
-      disabled={buttonIsLoading || !capacityAvailable}
+      disabled={buttonIsLoading}
     >
       <UserPlus className="h-4 w-4" />
-      {buttonIsLoading ? 'Inscribiéndote...' : 'Inscribirme al evento'}
+      {buttonIsLoading
+        ? 'Procesando...'
+        : capacityAvailable
+          ? 'Inscribirme al evento'
+          : 'Sumarme a lista de espera'}
     </Button>
   );
 }

--- a/src/components/home/sponsors-section.tsx
+++ b/src/components/home/sponsors-section.tsx
@@ -53,7 +53,7 @@ const sponsors = [
   },
   {
     name: 'Endpoint Consulting',
-    url: 'https://www.instagram.com/endpointconsulting/',
+    url: 'https://www.instagram.com/endpoint_ciberseguridad/',
     logo: '/endpoint-security-logo.png',
     description: 'Expertos en seguridad informática y consultoría tecnológica.',
     location: 'Tucumán, Argentina',


### PR DESCRIPTION
## Resumen

Se implementó soporte de inscripciones fuera de cupo mediante lista de espera para eventos con capacidad limitada, incluyendo promoción automática del siguiente usuario cuando se libera un lugar.

## Cambios principales

- Se agregó el modelo `EventWaitlistEntry` en Prisma y su migración.
- Se incorporó lógica centralizada de cupo/lista de espera/promoción en `src/actions/events/event-capacity.ts`.
- Se actualizó `registerEvent` para:
  - confirmar inscripción cuando hay cupo,
  - agregar a lista de espera cuando el cupo está completo,
  - evitar duplicados de inscripción/lista de espera por usuario.
- Se actualizó `cancelRegistration` y `deleteRegistration` para:
  - liberar cupo,
  - promover automáticamente al siguiente usuario en espera (FIFO).
- Se actualizó la UI del detalle de evento:
  - botón dinámico (`Inscribirme` / `Sumarme a lista de espera`),
  - estado de usuario en waitlist y posición.
- Se actualizó la vista admin de inscripciones para mostrar demanda fuera de cupo y tabla de espera activa.
- Se mantuvieron notificaciones a admins para altas, bajas y promociones.

## Test plan

- [ ] Crear evento con `capacity` baja (ej: 1 o 2).
- [ ] Inscribir usuarios hasta completar cupo.
- [ ] Verificar que nuevas inscripciones entren a lista de espera.
- [ ] Verificar visualización de demanda fuera de cupo en detalle del evento y vista admin.
- [ ] Cancelar o eliminar una inscripción activa y validar promoción automática del primero en espera.
- [ ] Verificar salida manual de lista de espera.
- [ ] Verificar que no se permitan duplicados (inscripción activa o waitlist repetida por usuario/evento).

## Evidencia (UI)

- [ ] Captura/video: cupo completo.
<img width="1139" height="432" alt="image" src="https://github.com/user-attachments/assets/950463af-ebda-482c-808a-47273a9651d5" />
<img width="272" height="117" alt="image" src="https://github.com/user-attachments/assets/f3519788-fc04-4469-a384-b601a50cb337" />
- [ ] Captura/video: alta en lista de espera.
<img width="1154" height="587" alt="image" src="https://github.com/user-attachments/assets/cea851ae-988d-4bbd-9a34-ee9ff0ae14d4" />
<img width="1141" height="528" alt="image" src="https://github.com/user-attachments/assets/ed96a057-4a41-43c0-9ff6-d8393d0c9060" />
- [ ] Captura/video: promoción automática al liberar cupo.
<img width="1139" height="428" alt="image" src="https://github.com/user-attachments/assets/db00b864-53f7-40d3-afc0-0ee3855c7203" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Event waitlist functionality—users can now join a waiting list when events reach full capacity
  * Waitlist position tracking—users can view their position in the queue
  * Automatic promotion—users are promoted from the waitlist when registration spots become available
  * Admin waitlist visibility—administrators can view and manage event waitlists

* **Bug Fixes**
  * Improved meetup page redirect behavior
  * Updated external sponsor link

<!-- end of auto-generated comment: release notes by coderabbit.ai -->