### PR TITLE
feat(usuarios): replace user card grid with shadcn DataTable

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@react-email/render": "^1.1.2",
     "@tabler/icons-react": "^3.12.0",
     "@tanstack/react-query": "^5.74.4",
+    "@tanstack/react-table": "^8.21.3",
     "@tsparticles/engine": "^3.5.0",
     "@tsparticles/react": "^3.0.0",
     "@tsparticles/slim": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.74.4
         version: 5.100.5(react@19.2.5)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tsparticles/engine':
         specifier: ^3.5.0
         version: 3.5.0
@@ -1991,11 +1994,22 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
   '@tanstack/react-virtual@3.13.24':
     resolution: {integrity: sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
 
   '@tanstack/virtual-core@3.14.0':
     resolution: {integrity: sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==}
@@ -6357,11 +6371,19 @@ snapshots:
       '@tanstack/query-core': 5.100.5
       react: 19.2.5
 
+  '@tanstack/react-table@8.21.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
   '@tanstack/react-virtual@3.13.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/virtual-core': 3.14.0
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
+
+  '@tanstack/table-core@8.21.3': {}
 
   '@tanstack/virtual-core@3.14.0': {}
 

--- a/src/actions/users/get-users.ts
+++ b/src/actions/users/get-users.ts
@@ -1,26 +1,31 @@
 'use server';
 import prisma from '@/lib/prisma';
 
-type UserWithoutPassword = {
+export type UserWithoutPassword = {
   id: string;
   name: string;
   email: string;
-  createdAt: Date;
+  emailVerified: boolean;
+  phoneNumber: string | null;
+  role: 'REGULAR' | 'ADMIN';
   image: string | null;
-  languages: {
-    language: string;
-    color: string;
-    logo: string;
-  }[];
-  linkedinUrl: string | null;
-  xAccountUrl: string | null;
-  gitHubUrl: string | null;
   countryOfOrigin: string | null;
+  province: string | null;
+  xAccountUrl: string | null;
+  linkedinUrl: string | null;
+  gitHubUrl: string | null;
   slogan: string | null;
   jobTitle: string | null;
   enterprise: string | null;
   career: string | null;
   studyPlace: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  languages: {
+    language: string;
+    color: string;
+    logo: string;
+  }[];
 };
 
 export const getUsers = async (): Promise<UserWithoutPassword[]> => {
@@ -29,8 +34,22 @@ export const getUsers = async (): Promise<UserWithoutPassword[]> => {
       id: true,
       name: true,
       email: true,
-      createdAt: true,
+      emailVerified: true,
+      phoneNumber: true,
+      role: true,
       image: true,
+      countryOfOrigin: true,
+      province: true,
+      xAccountUrl: true,
+      linkedinUrl: true,
+      gitHubUrl: true,
+      slogan: true,
+      jobTitle: true,
+      enterprise: true,
+      career: true,
+      studyPlace: true,
+      createdAt: true,
+      updatedAt: true,
       languages: {
         select: {
           language: true,
@@ -38,16 +57,8 @@ export const getUsers = async (): Promise<UserWithoutPassword[]> => {
           logo: true,
         },
       },
-      xAccountUrl: true,
-      linkedinUrl: true,
-      gitHubUrl: true,
-      countryOfOrigin: true,
-      slogan: true,
-      jobTitle: true,
-      enterprise: true,
-      career: true,
-      studyPlace: true,
     },
+    orderBy: { createdAt: 'desc' },
   });
 
   return users;

--- a/src/app/(platform)/usuarios/page.tsx
+++ b/src/app/(platform)/usuarios/page.tsx
@@ -11,110 +11,18 @@ import {
 } from '@/components/ui/breadcrumb';
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
-import { useState, useMemo, useEffect } from 'react';
-import { Search, Users, X } from 'lucide-react';
-import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { getUsers } from '@/actions/users/get-users';
-import UserCard from '@/components/comunity/user-card';
-
-type UserWithoutPassword = {
-  id: string;
-  name: string;
-  email: string;
-  createdAt: Date;
-  image: string | null;
-  languages: {
-    language: string;
-    color: string;
-    logo: string;
-  }[];
-  linkedinUrl: string | null;
-  xAccountUrl: string | null;
-  gitHubUrl: string | null;
-  countryOfOrigin: string | null;
-  slogan: string | null;
-  jobTitle: string | null;
-  enterprise: string | null;
-  career: string | null;
-  studyPlace: string | null;
-};
+import { useState, useEffect } from 'react';
+import { Users } from 'lucide-react';
+import { getUsers, UserWithoutPassword } from '@/actions/users/get-users';
+import { DataTable } from '@/components/comunity/data-table';
+import { columns } from '@/components/comunity/users-columns';
 
 const CommunityPage = () => {
-  const [searchTerm, setSearchTerm] = useState('');
-  const [selectedLocation, setSelectedLocation] = useState<string>('all');
-  const [selectedLanguage, setSelectedLanguage] = useState<string>('all');
   const [users, setUsers] = useState<UserWithoutPassword[]>([]);
 
   useEffect(() => {
-    const fetchUsers = async () => {
-      const fetchedUsers = await getUsers();
-      setUsers(fetchedUsers);
-    };
-    fetchUsers();
+    getUsers().then(setUsers);
   }, []);
-
-  const allLanguages = useMemo(() => {
-    const languages = new Set<string>();
-    users.forEach((user) => {
-      user.languages.forEach((lang) => {
-        languages.add(lang.language);
-      });
-    });
-    return Array.from(languages).sort();
-  }, [users]);
-
-  const allLocations = useMemo(() => {
-    const locations = new Set<string>();
-    users.forEach((user) => {
-      if (user.countryOfOrigin) {
-        locations.add(user.countryOfOrigin);
-      }
-    });
-    return Array.from(locations).sort();
-  }, [users]);
-
-  const filteredUsers = useMemo(() => {
-    return users.filter((user) => {
-      const matchesSearch =
-        user.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        user.email.toLowerCase().includes(searchTerm.toLowerCase()) ||
-        user.languages.some((lang) =>
-          lang.language.toLowerCase().includes(searchTerm.toLowerCase()),
-        );
-
-      const matchesLocation =
-        selectedLocation === 'all' || user.countryOfOrigin === selectedLocation;
-      const matchesLanguage =
-        selectedLanguage === 'all' || user.languages.some((l) => l.language === selectedLanguage);
-
-      return matchesSearch && matchesLocation && matchesLanguage;
-    });
-  }, [users, searchTerm, selectedLocation, selectedLanguage]);
-
-  const hasFilters = searchTerm || selectedLocation !== 'all' || selectedLanguage !== 'all';
-
-  const clearFilters = () => {
-    setSearchTerm('');
-    setSelectedLocation('all');
-    setSelectedLanguage('all');
-  };
-
-  const calcMembershipTime = (creationDate: Date): string => {
-    const today = new Date();
-    const diffInMs = today.getTime() - creationDate.getTime();
-    const diffInDays = Math.floor(diffInMs / (1000 * 60 * 60 * 24));
-
-    const rtf = new Intl.RelativeTimeFormat('es', { numeric: 'auto' });
-    return rtf.format(-diffInDays, 'day');
-  };
 
   return (
     <>
@@ -137,115 +45,16 @@ const CommunityPage = () => {
       </header>
       <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
         <div className="mt-4">
-          <div className="mb-4 flex items-center justify-between">
+          <div className="mb-6">
             <Heading2 className="m-0 flex items-center gap-3">
               <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-pcnPurple/30 bg-pcnPurple/10 dark:border-pcnGreen/50 dark:bg-pcnGreen/10 dark:shadow-[0_0_10px_rgba(4,244,190,0.4)]">
                 <Users className="h-5 w-5 text-pcnPurple dark:text-pcnGreen dark:drop-shadow-[0_0_8px_rgba(4,244,190,0.8)]" />
               </div>
               <span className="dark:drop-shadow-[0_0_12px_rgba(4,244,190,0.8)]">Usuarios</span>
             </Heading2>
-            <span className="text-sm text-muted-foreground">
-              {filteredUsers.length} de {users.length}
-            </span>
           </div>
 
-          {/* Filtros compactos */}
-          <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center">
-            <div className="relative flex-1">
-              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                placeholder="Buscar usuario..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                className="pl-9"
-              />
-              {searchTerm && (
-                <button
-                  onClick={() => setSearchTerm('')}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                >
-                  <X className="h-4 w-4" />
-                </button>
-              )}
-            </div>
-
-            <Select value={selectedLocation} onValueChange={setSelectedLocation}>
-              <SelectTrigger className="w-full sm:w-40">
-                <SelectValue placeholder="País" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">Todos los países</SelectItem>
-                {allLocations.map((location) => (
-                  <SelectItem key={location} value={location}>
-                    {location}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-
-            <Select value={selectedLanguage} onValueChange={setSelectedLanguage}>
-              <SelectTrigger className="w-full sm:w-40">
-                <SelectValue placeholder="Lenguaje" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">Todos</SelectItem>
-                {allLanguages.map((lang) => (
-                  <SelectItem key={lang} value={lang}>
-                    {lang}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          {/* Filtros activos */}
-          {hasFilters && (
-            <div className="mb-4 flex flex-wrap items-center gap-2">
-              {selectedLocation !== 'all' && (
-                <Badge
-                  variant="secondary"
-                  className="cursor-pointer gap-1"
-                  onClick={() => setSelectedLocation('all')}
-                >
-                  {selectedLocation}
-                  <X className="h-3 w-3" />
-                </Badge>
-              )}
-              {selectedLanguage !== 'all' && (
-                <Badge
-                  variant="secondary"
-                  className="cursor-pointer gap-1"
-                  onClick={() => setSelectedLanguage('all')}
-                >
-                  {selectedLanguage}
-                  <X className="h-3 w-3" />
-                </Badge>
-              )}
-              <button
-                onClick={clearFilters}
-                className="text-xs text-muted-foreground hover:text-foreground"
-              >
-                Limpiar todo
-              </button>
-            </div>
-          )}
-
-          {/* Grid de usuarios */}
-          {filteredUsers.length > 0 ? (
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-              {filteredUsers.map((user) => (
-                <UserCard
-                  key={user.id}
-                  user={user}
-                  calcMembershipTime={calcMembershipTime(user.createdAt)}
-                />
-              ))}
-            </div>
-          ) : (
-            <p className="py-12 text-center text-muted-foreground">
-              No se encontraron usuarios con estos filtros.
-            </p>
-          )}
+          <DataTable columns={columns} data={users} />
         </div>
       </div>
     </>

--- a/src/components/comunity/data-table.tsx
+++ b/src/components/comunity/data-table.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import {
+  ColumnDef,
+  ColumnFiltersState,
+  SortingState,
+  VisibilityState,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { Search, X, SlidersHorizontal, ChevronLeft, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+interface DataTableProps<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+}
+
+export function DataTable<TData, TValue>({ columns, data }: DataTableProps<TData, TValue>) {
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({
+    id: false,
+    province: false,
+    updatedAt: false,
+    xAccountUrl: false,
+    linkedinUrl: false,
+    gitHubUrl: false,
+    image: false,
+  });
+  const [globalFilter, setGlobalFilter] = useState('');
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: {
+      sorting,
+      columnFilters,
+      columnVisibility,
+      globalFilter,
+    },
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onColumnVisibilityChange: setColumnVisibility,
+    onGlobalFilterChange: setGlobalFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: {
+      pagination: { pageSize: 20 },
+    },
+  });
+
+  const columnLabels: Record<string, string> = {
+    name: 'Nombre',
+    email: 'Email',
+    emailVerified: 'Verificado',
+    phoneNumber: 'Teléfono',
+    role: 'Rol',
+    image: 'Avatar',
+    countryOfOrigin: 'País',
+    province: 'Provincia',
+    languages: 'Lenguajes',
+    linkedinUrl: 'LinkedIn',
+    xAccountUrl: 'X / Twitter',
+    gitHubUrl: 'GitHub',
+    slogan: 'Slogan',
+    jobTitle: 'Cargo',
+    enterprise: 'Empresa',
+    career: 'Carrera',
+    studyPlace: 'Lugar de estudio',
+    createdAt: 'Miembro desde',
+    updatedAt: 'Actualizado',
+    id: 'ID',
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Toolbar */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Buscar usuario..."
+            value={globalFilter}
+            onChange={(e) => setGlobalFilter(e.target.value)}
+            className="pl-9"
+          />
+          {globalFilter && (
+            <button
+              onClick={() => setGlobalFilter('')}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-muted-foreground">
+            {table.getFilteredRowModel().rows.length} de {data.length}
+          </span>
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="sm" className="gap-2">
+                <SlidersHorizontal className="h-4 w-4" />
+                Columnas
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuLabel>Mostrar columnas</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              {table
+                .getAllColumns()
+                .filter((col) => col.getCanHide())
+                .map((col) => (
+                  <DropdownMenuCheckboxItem
+                    key={col.id}
+                    checked={col.getIsVisible()}
+                    onCheckedChange={(value) => col.toggleVisibility(!!value)}
+                  >
+                    {columnLabels[col.id] ?? col.id}
+                  </DropdownMenuCheckboxItem>
+                ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((hg) => (
+              <TableRow key={hg.id}>
+                {hg.headers.map((header) => (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell colSpan={columns.length} className="h-24 text-center text-muted-foreground">
+                  No se encontraron usuarios.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          Página {table.getState().pagination.pageIndex + 1} de {table.getPageCount()}
+        </p>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Anterior
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            Siguiente
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/comunity/users-columns.tsx
+++ b/src/components/comunity/users-columns.tsx
@@ -1,0 +1,349 @@
+'use client';
+
+import { ColumnDef } from '@tanstack/react-table';
+import { ArrowUpDown, Github, Linkedin, Twitter } from 'lucide-react';
+
+import { UserWithoutPassword } from '@/actions/users/get-users';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { LocalDateTime } from '@/components/ui/local-date-time';
+
+function SortableHeader({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <Button variant="ghost" size="sm" className="-ml-3 gap-1" onClick={onClick}>
+      {label}
+      <ArrowUpDown className="h-3.5 w-3.5 text-muted-foreground" />
+    </Button>
+  );
+}
+
+function EmptyCell() {
+  return <span className="text-muted-foreground">—</span>;
+}
+
+export const columns: ColumnDef<UserWithoutPassword>[] = [
+  {
+    accessorKey: 'id',
+    header: 'ID',
+    cell: ({ getValue }) => (
+      <span className="font-mono text-xs text-muted-foreground">{getValue<string>()}</span>
+    ),
+    enableHiding: true,
+  },
+  {
+    accessorKey: 'name',
+    header: ({ column }) => (
+      <SortableHeader label="Nombre" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')} />
+    ),
+    cell: ({ row }) => {
+      const { name, image } = row.original;
+      const initials = name
+        .split(' ')
+        .map((n) => n[0])
+        .slice(0, 2)
+        .join('')
+        .toUpperCase();
+      return (
+        <div className="flex items-center gap-2">
+          <Avatar className="h-7 w-7">
+            <AvatarImage src={image ?? undefined} alt={name} />
+            <AvatarFallback className="text-xs">{initials}</AvatarFallback>
+          </Avatar>
+          <span className="font-medium">{name}</span>
+        </div>
+      );
+    },
+  },
+  {
+    accessorKey: 'email',
+    header: ({ column }) => (
+      <SortableHeader label="Email" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')} />
+    ),
+    cell: ({ row }) => {
+      const { email, emailVerified } = row.original;
+      return (
+        <div className="flex flex-col gap-0.5">
+          <span className="text-sm">{email}</span>
+          {emailVerified ? (
+            <Badge variant="outline" className="w-fit border-green-500/40 bg-green-500/10 text-xs text-green-600 dark:text-green-400">
+              Verificado
+            </Badge>
+          ) : (
+            <Badge variant="outline" className="w-fit text-xs text-muted-foreground">
+              Sin verificar
+            </Badge>
+          )}
+        </div>
+      );
+    },
+  },
+  {
+    accessorKey: 'emailVerified',
+    header: 'Email verificado',
+    cell: ({ getValue }) =>
+      getValue<boolean>() ? (
+        <Badge variant="outline" className="border-green-500/40 bg-green-500/10 text-green-600 dark:text-green-400">
+          Sí
+        </Badge>
+      ) : (
+        <Badge variant="outline" className="text-muted-foreground">
+          No
+        </Badge>
+      ),
+    enableHiding: true,
+  },
+  {
+    accessorKey: 'role',
+    header: ({ column }) => (
+      <SortableHeader label="Rol" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')} />
+    ),
+    cell: ({ getValue }) => {
+      const role = getValue<'REGULAR' | 'ADMIN'>();
+      return role === 'ADMIN' ? (
+        <Badge className="bg-pcnPurple/20 text-pcnPurple dark:bg-pcnGreen/20 dark:text-pcnGreen">
+          Admin
+        </Badge>
+      ) : (
+        <Badge variant="secondary">Regular</Badge>
+      );
+    },
+  },
+  {
+    accessorKey: 'phoneNumber',
+    header: 'Teléfono',
+    cell: ({ getValue }) => {
+      const v = getValue<string | null>();
+      return v ? <span className="text-sm">{v}</span> : <EmptyCell />;
+    },
+  },
+  {
+    accessorKey: 'countryOfOrigin',
+    header: ({ column }) => (
+      <SortableHeader label="País" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')} />
+    ),
+    cell: ({ getValue }) => {
+      const v = getValue<string | null>();
+      return v ? <span className="text-sm">{v}</span> : <EmptyCell />;
+    },
+  },
+  {
+    accessorKey: 'province',
+    header: 'Provincia',
+    cell: ({ getValue }) => {
+      const v = getValue<string | null>();
+      return v ? <span className="text-sm">{v}</span> : <EmptyCell />;
+    },
+    enableHiding: true,
+  },
+  {
+    accessorKey: 'jobTitle',
+    header: 'Cargo',
+    cell: ({ row }) => {
+      const { jobTitle, enterprise } = row.original;
+      if (!jobTitle) return <EmptyCell />;
+      return (
+        <div className="text-sm">
+          <p className="font-medium">{jobTitle}</p>
+          {enterprise && <p className="text-muted-foreground">{enterprise}</p>}
+        </div>
+      );
+    },
+  },
+  {
+    accessorKey: 'enterprise',
+    header: 'Empresa',
+    cell: ({ getValue }) => {
+      const v = getValue<string | null>();
+      return v ? <span className="text-sm">{v}</span> : <EmptyCell />;
+    },
+    enableHiding: true,
+  },
+  {
+    accessorKey: 'career',
+    header: 'Carrera',
+    cell: ({ row }) => {
+      const { career, studyPlace } = row.original;
+      if (!career) return <EmptyCell />;
+      return (
+        <div className="text-sm">
+          <p className="font-medium">{career}</p>
+          {studyPlace && <p className="text-muted-foreground">{studyPlace}</p>}
+        </div>
+      );
+    },
+  },
+  {
+    accessorKey: 'studyPlace',
+    header: 'Lugar de estudio',
+    cell: ({ getValue }) => {
+      const v = getValue<string | null>();
+      return v ? <span className="text-sm">{v}</span> : <EmptyCell />;
+    },
+    enableHiding: true,
+  },
+  {
+    accessorKey: 'slogan',
+    header: 'Slogan',
+    cell: ({ getValue }) => {
+      const v = getValue<string | null>();
+      return v ? (
+        <span className="max-w-[200px] truncate text-sm italic text-muted-foreground">{v}</span>
+      ) : (
+        <EmptyCell />
+      );
+    },
+  },
+  {
+    accessorKey: 'languages',
+    header: 'Lenguajes',
+    cell: ({ getValue }) => {
+      const langs = getValue<UserWithoutPassword['languages']>();
+      if (!langs.length) return <EmptyCell />;
+      return (
+        <div className="flex flex-wrap gap-1">
+          {langs.map((l) => (
+            <Badge
+              key={l.language}
+              variant="outline"
+              className="text-xs"
+              style={{ borderColor: `${l.color}55`, color: l.color }}
+            >
+              {l.language}
+            </Badge>
+          ))}
+        </div>
+      );
+    },
+    enableSorting: false,
+  },
+  {
+    id: 'socials',
+    header: 'Redes',
+    cell: ({ row }) => {
+      const { linkedinUrl, xAccountUrl, gitHubUrl } = row.original;
+      if (!linkedinUrl && !xAccountUrl && !gitHubUrl) return <EmptyCell />;
+      return (
+        <div className="flex items-center gap-2">
+          {linkedinUrl && (
+            <a
+              href={linkedinUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-muted-foreground transition-colors hover:text-foreground"
+              title="LinkedIn"
+            >
+              <Linkedin className="h-4 w-4" />
+            </a>
+          )}
+          {xAccountUrl && (
+            <a
+              href={xAccountUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-muted-foreground transition-colors hover:text-foreground"
+              title="X / Twitter"
+            >
+              <Twitter className="h-4 w-4" />
+            </a>
+          )}
+          {gitHubUrl && (
+            <a
+              href={gitHubUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-muted-foreground transition-colors hover:text-foreground"
+              title="GitHub"
+            >
+              <Github className="h-4 w-4" />
+            </a>
+          )}
+        </div>
+      );
+    },
+    enableSorting: false,
+    enableHiding: true,
+  },
+  {
+    accessorKey: 'linkedinUrl',
+    header: 'LinkedIn',
+    cell: ({ getValue }) => {
+      const v = getValue<string | null>();
+      return v ? (
+        <a href={v} target="_blank" rel="noopener noreferrer" className="text-xs text-blue-500 hover:underline">
+          {v}
+        </a>
+      ) : (
+        <EmptyCell />
+      );
+    },
+    enableHiding: true,
+  },
+  {
+    accessorKey: 'xAccountUrl',
+    header: 'X / Twitter',
+    cell: ({ getValue }) => {
+      const v = getValue<string | null>();
+      return v ? (
+        <a href={v} target="_blank" rel="noopener noreferrer" className="text-xs text-blue-500 hover:underline">
+          {v}
+        </a>
+      ) : (
+        <EmptyCell />
+      );
+    },
+    enableHiding: true,
+  },
+  {
+    accessorKey: 'gitHubUrl',
+    header: 'GitHub',
+    cell: ({ getValue }) => {
+      const v = getValue<string | null>();
+      return v ? (
+        <a href={v} target="_blank" rel="noopener noreferrer" className="text-xs text-blue-500 hover:underline">
+          {v}
+        </a>
+      ) : (
+        <EmptyCell />
+      );
+    },
+    enableHiding: true,
+  },
+  {
+    accessorKey: 'image',
+    header: 'Avatar URL',
+    cell: ({ getValue }) => {
+      const v = getValue<string | null>();
+      return v ? (
+        <span className="max-w-[150px] truncate font-mono text-xs text-muted-foreground">{v}</span>
+      ) : (
+        <EmptyCell />
+      );
+    },
+    enableHiding: true,
+  },
+  {
+    accessorKey: 'createdAt',
+    header: ({ column }) => (
+      <SortableHeader
+        label="Miembro desde"
+        onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+      />
+    ),
+    cell: ({ getValue }) => (
+      <span className="whitespace-nowrap text-sm text-muted-foreground">
+        <LocalDateTime date={getValue<Date>()} />
+      </span>
+    ),
+  },
+  {
+    accessorKey: 'updatedAt',
+    header: 'Actualizado',
+    cell: ({ getValue }) => (
+      <span className="whitespace-nowrap text-sm text-muted-foreground">
+        <LocalDateTime date={getValue<Date>()} />
+      </span>
+    ),
+    enableHiding: true,
+  },
+];


### PR DESCRIPTION
## Summary

- Replaces the admin `/usuarios` page card grid with a full **shadcn DataTable** (TanStack Table v8) showing all non-password user fields
- Adds global search, per-column sorting, column visibility toggle, and pagination (20 rows/page)
- Widens `getUsers()` to include `phoneNumber`, `province`, `role`, `emailVerified`, and `updatedAt`

## New files

- `src/components/comunity/data-table.tsx` — reusable generic DataTable shell
- `src/components/comunity/users-columns.tsx` — column defs with colored language badges, social icon links, role/verified badges, and sortable headers

## Test plan

- [ ] Navigate to `/usuarios` as an ADMIN — table renders with all users
- [ ] Global search filters rows across name, email, and other text fields
- [ ] Clicking sortable column headers (Nombre, Email, Rol, País, Miembro desde) sorts asc/desc
- [ ] "Columnas" dropdown toggles hidden columns (id, province, updatedAt, raw URLs hidden by default)
- [ ] Pagination Prev/Next works; count updates correctly
- [ ] Non-admin users are still redirected to `/home` by the layout guard
- [ ] `password` field is never present in the network response