### PR TITLE
fix(registro): keep submit button disabled after successful sign-up

### DIFF
--- a/src/app/autenticacion/registro/page.tsx
+++ b/src/app/autenticacion/registro/page.tsx
@@ -110,12 +110,15 @@ function SignUpContent() {
       if (result.success) {
         toast.success('Usuario creado exitosamente! 🥳');
         // Redirigir a la página de verificación
-        // No deshabilitamos isSubmitting aquí para mantener el botón deshabilitado durante la redirección
+        // No llamamos setIsSubmitting(false) aquí para mantener el botón deshabilitado durante la redirección
         if (result.redirectUrl) {
           router.push(result.redirectUrl);
         }
         return;
       }
+
+      // Rehabilitar el botón solo en caso de error
+      setIsSubmitting(false);
 
       // Manejar errores específicos
       if (result.error === 'EMAIL_ALREADY_EXISTS') {
@@ -124,10 +127,8 @@ function SignUpContent() {
         toast.error('Error al crear el usuario. Por favor, intentá nuevamente.');
       }
     } catch (error) {
-      toast.error('Ocurrió un error inesperado. Por favor, intentá nuevamente.');
-    } finally {
-      // Solo rehabilitar el botón si hubo un error
       setIsSubmitting(false);
+      toast.error('Ocurrió un error inesperado. Por favor, intentá nuevamente.');
     }
   };
 


### PR DESCRIPTION
## Summary

- The `finally` block in the sign-up `onSubmit` handler was unconditionally calling `setIsSubmitting(false)` on every path, including success
- This re-enabled the submit button during the `router.push()` redirect window, allowing a second click
- The second request hit the `EMAIL_ALREADY_EXISTS` pre-check and showed an error to the user, even though their account was created successfully

## Changes

- Removed the `finally` block
- `setIsSubmitting(false)` is now called only in error branches (known error, unexpected catch), keeping the button disabled through the redirect on success

## Test plan

- [ ] Submit with a fresh email → button stays disabled (spinner) through redirect to `/autenticacion/verificar-email`, no double-submission error
- [ ] Submit with an existing email → button re-enables and "Ya hay un usuario con ese correo electrónico" toast appears so the user can retry
- [ ] Submit with a network/unexpected error → button re-enables and generic error toast appears