### PR TITLE
style(eventos): make event detail columns equal width

### DIFF
--- a/src/app/(platform)/eventos/[id]/page.tsx
+++ b/src/app/(platform)/eventos/[id]/page.tsx
@@ -259,8 +259,8 @@ const EventDetailPage: React.FC<{ params: Promise<{ id: string }> }> = async (pr
           </div>
 
           <div className="my-5 ml-0 flex flex-col gap-5 xl:flex-row">
-            {/* Columna principal — flyer (ancho fijo) */}
-            <div className="flex w-full flex-col gap-5 xl:w-96">
+            {/* Columna principal — flyer */}
+            <div className="flex w-full flex-col gap-5 xl:flex-1">
               {/* Flyer del evento */}
               <Card className={cn(sectionCardClassName, 'overflow-hidden')}>
                 <div className="relative w-full overflow-hidden">
@@ -309,7 +309,7 @@ const EventDetailPage: React.FC<{ params: Promise<{ id: string }> }> = async (pr
               )}
             </div>
 
-            {/* Columna de información (crece para llenar el espacio) */}
+            {/* Columna de información */}
             <div className="flex w-full flex-col gap-5 xl:flex-1">
               {/* Descripción */}
               {event.description && (


### PR DESCRIPTION
## Summary

- Replace fixed `xl:w-96` on the flyer column with `xl:flex-1` so both columns share the available space equally at wide (`xl`+) viewports
- Mobile/tablet stacked layout is unchanged

## Test plan

- [ ] Open an event detail page at a wide viewport and confirm the flyer and info columns are equal width
- [ ] Narrow below `xl` and confirm columns stack full-width as before