### PR TITLE
feat(usuarios): load users server-side, increase page size and column widths

### DIFF
--- a/src/app/(platform)/usuarios/page.tsx
+++ b/src/app/(platform)/usuarios/page.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Heading2 } from '@/components/ui/heading-2';
 import {
   Breadcrumb,
@@ -11,18 +9,13 @@ import {
 } from '@/components/ui/breadcrumb';
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
-import { useState, useEffect } from 'react';
 import { Users } from 'lucide-react';
-import { getUsers, UserWithoutPassword } from '@/actions/users/get-users';
+import { getUsers } from '@/actions/users/get-users';
 import { DataTable } from '@/components/comunity/data-table';
 import { columns } from '@/components/comunity/users-columns';
 
-const CommunityPage = () => {
-  const [users, setUsers] = useState<UserWithoutPassword[]>([]);
-
-  useEffect(() => {
-    getUsers().then(setUsers);
-  }, []);
+const CommunityPage = async () => {
+  const users = await getUsers();
 
   return (
     <>

--- a/src/components/comunity/data-table.tsx
+++ b/src/components/comunity/data-table.tsx
@@ -71,7 +71,7 @@ export function DataTable<TData, TValue>({ columns, data }: DataTableProps<TData
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     initialState: {
-      pagination: { pageSize: 20 },
+      pagination: { pageSize: 100 },
     },
   });
 
@@ -159,7 +159,10 @@ export function DataTable<TData, TValue>({ columns, data }: DataTableProps<TData
             {table.getHeaderGroups().map((hg) => (
               <TableRow key={hg.id}>
                 {hg.headers.map((header) => (
-                  <TableHead key={header.id}>
+                  <TableHead
+                    key={header.id}
+                    className={(header.column.columnDef.meta as { className?: string } | undefined)?.className}
+                  >
                     {header.isPlaceholder
                       ? null
                       : flexRender(header.column.columnDef.header, header.getContext())}
@@ -173,7 +176,10 @@ export function DataTable<TData, TValue>({ columns, data }: DataTableProps<TData
               table.getRowModel().rows.map((row) => (
                 <TableRow key={row.id} data-state={row.getIsSelected() && 'selected'}>
                   {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
+                    <TableCell
+                      key={cell.id}
+                      className={(cell.column.columnDef.meta as { className?: string } | undefined)?.className}
+                    >
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}
                     </TableCell>
                   ))}

--- a/src/components/comunity/users-columns.tsx
+++ b/src/components/comunity/users-columns.tsx
@@ -33,6 +33,7 @@ export const columns: ColumnDef<UserWithoutPassword>[] = [
   },
   {
     accessorKey: 'name',
+    meta: { className: 'min-w-[220px] whitespace-nowrap' },
     header: ({ column }) => (
       <SortableHeader label="Nombre" onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')} />
     ),
@@ -161,6 +162,7 @@ export const columns: ColumnDef<UserWithoutPassword>[] = [
   },
   {
     accessorKey: 'career',
+    meta: { className: 'min-w-[200px]' },
     header: 'Carrera',
     cell: ({ row }) => {
       const { career, studyPlace } = row.original;


### PR DESCRIPTION
## Summary

- Convert `/usuarios` page from a client component (`useEffect` + state) to an async server component — users are now fetched at render time, eliminating the empty-table flash on first paint
- Increase default page size from 20 to 100 rows
- Widen the **Nombre** column (`min-w-[220px]`) and the **Carrera** column (`min-w-[200px]`) via a `meta.className` mechanism forwarded to `<TableHead>` and `<TableCell>`

## Test plan

- [ ] Open `/usuarios` — table should render populated on first paint (no flash)
- [ ] Verify page shows up to 100 rows before paginating
- [ ] Confirm Nombre and Carrera columns are visibly wider than before