### PR TITLE
feat(historia): enrich page with production events 2021-2026

### DIFF
--- a/src/app/(platform)/historia/page.tsx
+++ b/src/app/(platform)/historia/page.tsx
@@ -419,12 +419,20 @@ const PCNStory = () => (
               <CardHeader>
                 <CardTitle>Lightning Talks</CardTitle>
               </CardHeader>
-              <CardContent>
+              <CardContent className="space-y-4">
                 <p className="text-base text-muted-foreground md:text-sm">
                   Organizamos varias jornadas de Lightning Talks, donde muchos miembros de la
                   comunidad comparten su conocimiento y experiencias. Al principio eran todas
                   virtuales por Discord, y cuando se terminó la cuarentena y se pudo volver a la
                   vida de antes, organizamos varias ediciones de Lightning Talks presenciales.
+                </p>
+                <p className="text-base text-muted-foreground md:text-sm">
+                  La primera edición fue en junio de 2021, de forma virtual por Discord, con charlas
+                  rápidas sobre ingeniería de software. Con la vuelta a la presencialidad, las
+                  Lightning Talks encontraron su lugar en el SUM 1 de la UTN-FRT: organizamos una
+                  edición en mayo de 2023 y otra en octubre de 2024, convocando a cada vez más
+                  miembros de la comunidad a subirse al escenario y compartir lo que estaban
+                  aprendiendo.
                 </p>
               </CardContent>
             </Card>
@@ -465,6 +473,109 @@ const PCNStory = () => (
                   Navarro, Mauricio Chaile, Matías Gutierrez, Nicolas Fuentes, Facundo Bazán, Vicky
                   Grillo, Emiliano Grillo, Carlos Spagnolo, Alejo Boga, Tobías Paz Posse, Marcelo
                   Núñez y Benjamin Cortes. El equipo fue liderado por Agustín Sánchez.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card
+              id="charlas-comunidad"
+              className="w-full max-w-4xl scroll-mt-24 border-0 bg-transparent shadow-none md:border md:bg-card md:shadow-sm md:transition-colors"
+            >
+              <CardHeader>
+                <CardTitle>Compartiendo con la industria y las escuelas</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <p className="text-base text-muted-foreground md:text-sm">
+                  A medida que la comunidad fue creciendo, empezamos a salir de la universidad para
+                  llevar nuestra experiencia a otros espacios. En noviembre de 2023 organizamos{' '}
+                  <b>Una Mirada de la Industria del Software</b> en el Mercado Municipal de Tafí
+                  Viejo, donde ingenieros senior de la comunidad compartieron metodologías, técnicas
+                  y una visión honesta de cómo funciona la industria del software en la actualidad.
+                </p>
+                <p className="text-base text-muted-foreground md:text-sm">
+                  En octubre de 2024 fuimos invitados a dar dos charlas de orientación vocacional.
+                  La primera, <b>Descubrí el Mundo del Desarrollo de Software</b>, se llevó a cabo
+                  en Aticana, donde recorrimos los distintos roles y caminos posibles dentro de la
+                  profesión. La segunda, <b>Introducción al Desarrollo de Software</b>, la dimos en
+                  el Instituto Nuestra Señora de Montserrat para estudiantes de secundaria que
+                  estaban dando sus primeros pasos en este mundo.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card
+              id="tech-in-action"
+              className="w-full max-w-4xl scroll-mt-24 border-0 bg-transparent shadow-none md:border md:bg-card md:shadow-sm md:transition-colors"
+            >
+              <CardHeader>
+                <CardTitle>Tech in Action</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <p className="text-base text-muted-foreground md:text-sm">
+                  En junio de 2025, en el marco del Mes de la Ingeniería, la UTN-FRT nos abrió
+                  nuevamente las puertas del SUM 1 para organizar <b>Tech in Action</b>: dos
+                  presentaciones técnicas a cargo de miembros de la comunidad que mostraron
+                  proyectos reales y herramientas que estaban usando en su trabajo cotidiano.
+                </p>
+                <p className="text-base text-muted-foreground md:text-sm">
+                  El evento reunió a estudiantes, egresados y profesionales de la industria, y fue
+                  una muestra más de que PCN sigue siendo un puente entre la academia y el mundo
+                  laboral.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card
+              id="era-meetups"
+              className="w-full max-w-4xl scroll-mt-24 border-0 bg-transparent shadow-none md:border md:bg-card md:shadow-sm md:transition-colors"
+            >
+              <CardHeader>
+                <CardTitle>La era de los Meetups</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <p className="text-base text-muted-foreground md:text-sm">
+                  A partir de 2025, la comunidad adoptó un nuevo formato que se convirtió en el
+                  corazón de la actividad de PCN: los meetups mensuales. Con sedes que rotaron entre
+                  Blackbox Cowork (Yerba Buena), Once57 Cowork y Xetro AI (San Miguel de Tucumán),
+                  cada encuentro combinó charlas técnicas, networking y trabajo colaborativo en un
+                  ambiente relajado.
+                </p>
+                <p className="text-base text-muted-foreground md:text-sm">
+                  También incorporamos las <b>Cowork Sessions</b>, jornadas de trabajo y estudio en
+                  comunidad donde los miembros se juntan a avanzar en sus proyectos, preparar
+                  entrevistas o simplemente programar acompañados. Estas sesiones se convirtieron en
+                  un espacio muy valorado por quienes están en modo aprendizaje intensivo.
+                </p>
+                <p className="text-base text-muted-foreground md:text-sm">
+                  El cierre de 2025 fue en Blackbox Cowork con un meetup especial de fin de año:
+                  coworking, charlas y mucho networking para despedir un año muy activo para la
+                  comunidad.
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card
+              id="hackathons-y-nextgen"
+              className="w-full max-w-4xl scroll-mt-24 border-0 bg-transparent shadow-none md:border md:bg-card md:shadow-sm md:transition-colors"
+            >
+              <CardHeader>
+                <CardTitle>Zero to Agent y NextGen Software 2026</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <p className="text-base text-muted-foreground md:text-sm">
+                  En abril de 2026 organizamos <b>Zero to Agent</b>, el primer hackathon de PCN
+                  dedicado al desarrollo de agentes de IA. El evento se realizó en Once57 Cowork y
+                  desafió a los participantes a construir agentes usando Vercel v0, con más de USD
+                  6.000 en premios globales en juego. Fue una apuesta fuerte al futuro de la
+                  ingeniería de software y demostró que la comunidad está al día con lo que viene.
+                </p>
+                <p className="text-base text-muted-foreground md:text-sm">
+                  En junio de 2026, en el marco del 40° aniversario de la carrera de Ingeniería en
+                  Sistemas de Información de la UTN-FRT, co-organizamos{' '}
+                  <b>NextGen Software 2026</b>, unas jornadas para celebrar el Mes de la Ingeniería
+                  y reflexionar sobre el pasado, el presente y el futuro de la profesión. Un evento
+                  que nos dejó muy orgullosos de todo el camino recorrido desde aquel laboratorio de
+                  algoritmos en 2015.
                 </p>
               </CardContent>
             </Card>

--- a/src/app/(platform)/historia/page.tsx
+++ b/src/app/(platform)/historia/page.tsx
@@ -434,6 +434,32 @@ const PCNStory = () => (
                   miembros de la comunidad a subirse al escenario y compartir lo que estaban
                   aprendiendo.
                 </p>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                  <div className="flex justify-center">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src="https://d374fgq95bfr8o.cloudfront.net/events/flyers/1777242335684-7df020ca-0179-422e-9084-4dbbb6ed20f1.jpeg"
+                      alt="Lightning Talks 2021"
+                      className="max-w-full rounded-lg"
+                    />
+                  </div>
+                  <div className="flex justify-center">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src="https://d374fgq95bfr8o.cloudfront.net/events/flyers/1777242053412-bee91069-37b8-4d27-91cb-2fafcfdf92c9.jpeg"
+                      alt="Lightning Talks 2023"
+                      className="max-w-full rounded-lg"
+                    />
+                  </div>
+                  <div className="flex justify-center">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src="https://d374fgq95bfr8o.cloudfront.net/events/flyers/1777235792921-7d89c0da-a617-4e80-8a2b-6cc7cea2d0b8.jpeg"
+                      alt="Lightning Talks 2024"
+                      className="max-w-full rounded-lg"
+                    />
+                  </div>
+                </div>
               </CardContent>
             </Card>
 
@@ -500,6 +526,32 @@ const PCNStory = () => (
                   el Instituto Nuestra Señora de Montserrat para estudiantes de secundaria que
                   estaban dando sus primeros pasos en este mundo.
                 </p>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                  <div className="flex justify-center">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src="https://d374fgq95bfr8o.cloudfront.net/events/flyers/1777241814466-2b43047c-27f0-4de7-86a2-faabca4f1ac9.jpeg"
+                      alt="Una Mirada de la Industria del Software"
+                      className="max-w-full rounded-lg"
+                    />
+                  </div>
+                  <div className="flex justify-center">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src="https://d374fgq95bfr8o.cloudfront.net/events/flyers/1777236239325-19d0cf0e-4385-4e14-ac61-a2c20fb06bb0.jpeg"
+                      alt="Descubrí el Mundo del Desarrollo de Software"
+                      className="max-w-full rounded-lg"
+                    />
+                  </div>
+                  <div className="flex justify-center">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src="https://d374fgq95bfr8o.cloudfront.net/events/flyers/1777241043347-93b51aef-47ba-4e88-9a9c-a4aaa997f6c2.jpeg"
+                      alt="Introducción al Desarrollo de Software"
+                      className="max-w-full rounded-lg"
+                    />
+                  </div>
+                </div>
               </CardContent>
             </Card>
 
@@ -522,6 +574,14 @@ const PCNStory = () => (
                   una muestra más de que PCN sigue siendo un puente entre la academia y el mundo
                   laboral.
                 </p>
+                <div className="flex justify-center">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src="https://d374fgq95bfr8o.cloudfront.net/events/flyers/1777236349066-ae60a5c3-81d2-4cd8-bc18-85b648d4f089.jpeg"
+                    alt="Tech in Action"
+                    className="max-w-full rounded-lg"
+                  />
+                </div>
               </CardContent>
             </Card>
 
@@ -551,6 +611,48 @@ const PCNStory = () => (
                   coworking, charlas y mucho networking para despedir un año muy activo para la
                   comunidad.
                 </p>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                  <div className="flex justify-center">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src="https://d374fgq95bfr8o.cloudfront.net/events/flyers/1766992051811-4f6bc2cb-ebe4-47e3-b701-dd537a0590fe.jpeg"
+                      alt="Meetup diciembre 2025"
+                      className="max-w-full rounded-lg"
+                    />
+                  </div>
+                  <div className="flex justify-center">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src="https://d374fgq95bfr8o.cloudfront.net/events/flyers/1771359135414-cc6b3a49-722f-400c-99f2-b049d32a23ec.JPG"
+                      alt="Meetup febrero 2026"
+                      className="max-w-full rounded-lg"
+                    />
+                  </div>
+                  <div className="flex justify-center">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src="https://d374fgq95bfr8o.cloudfront.net/events/flyers/1775498317125-414e180b-4b7c-43b0-9848-64e89c4506af.PNG"
+                      alt="Meetup abril 2026"
+                      className="max-w-full rounded-lg"
+                    />
+                  </div>
+                  <div className="flex justify-center">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src="https://d374fgq95bfr8o.cloudfront.net/events/flyers/1776732685244-11d00b6f-78b7-460b-a1a8-11d40f0a852f.png"
+                      alt="Cowork Session"
+                      className="max-w-full rounded-lg"
+                    />
+                  </div>
+                  <div className="flex justify-center">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src="https://d374fgq95bfr8o.cloudfront.net/events/flyers/1779314634681-9a349677-eb94-4345-b69b-6eef31325aa1.png"
+                      alt="Meetup mayo 2026"
+                      className="max-w-full rounded-lg"
+                    />
+                  </div>
+                </div>
               </CardContent>
             </Card>
 
@@ -577,6 +679,24 @@ const PCNStory = () => (
                   que nos dejó muy orgullosos de todo el camino recorrido desde aquel laboratorio de
                   algoritmos en 2015.
                 </p>
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                  <div className="flex justify-center">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src="https://d374fgq95bfr8o.cloudfront.net/events/flyers/1777412831586-c7e9da58-e2a2-40d9-853a-e06cc1a5aace.png"
+                      alt="Zero to Agent"
+                      className="max-w-full rounded-lg"
+                    />
+                  </div>
+                  <div className="flex justify-center">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src="https://d374fgq95bfr8o.cloudfront.net/events/flyers/1780980085496-3a4b53b8-7df0-4259-a25a-d8d86873493b.png"
+                      alt="NextGen Software 2026"
+                      className="max-w-full rounded-lg"
+                    />
+                  </div>
+                </div>
               </CardContent>
             </Card>
           </div>

--- a/src/components/historia/table-of-contents.tsx
+++ b/src/components/historia/table-of-contents.tsx
@@ -18,6 +18,10 @@ const sections = [
   { id: 'lightning-talks', title: 'Lightning Talks' },
   { id: 'pcn-global-learning', title: 'PCN & Global Learning' },
   { id: 'desarrollo-website', title: 'Empezamos a desarrollar el website' },
+  { id: 'charlas-comunidad', title: 'Compartiendo con la industria y las escuelas' },
+  { id: 'tech-in-action', title: 'Tech in Action' },
+  { id: 'era-meetups', title: 'La era de los Meetups' },
+  { id: 'hackathons-y-nextgen', title: 'Zero to Agent y NextGen Software 2026' },
 ];
 
 export function TableOfContents() {


### PR DESCRIPTION
## Summary

- Enriches the `/historia` page narrative with the community's real events sourced from the production `/eventos` page (15 events spanning 2021–2026)
- Adds 4 new static narrative Card sections after "Empezamos a desarrollar el website"
- Enriches the existing Lightning Talks section with concrete edition dates
- Updates the `TableOfContents` `sections` array to keep sidebar nav and scroll-spy in sync

## New sections

| Section ID | Title | Events covered |
|---|---|---|
| `charlas-comunidad` | Compartiendo con la industria y las escuelas | Una Mirada de la Industria del Software (Tafí Viejo, nov 2023), Descubrí el Mundo del Desarrollo de Software (Aticana, oct 2024), Introducción al Desarrollo de Software (Inst. Montserrat, oct 2024) |
| `tech-in-action` | Tech in Action | UTN-FRT SUM 1, jun 2025, Mes de la Ingeniería |
| `era-meetups` | La era de los Meetups | Meetups mensuales y Cowork Sessions 2025–2026 (Blackbox Cowork, Once57, Xetro AI) |
| `hackathons-y-nextgen` | Zero to Agent y NextGen Software 2026 | Hackathon Zero to Agent (abr 2026, +USD 6000) + NextGen Software 2026 (jun 2026, 40° aniversario Ing. Sistemas UTN-FRT) |

## Test plan

- [ ] Open `/historia` and confirm the 4 new sections render after "Empezamos a desarrollar el website"
- [ ] Confirm the Lightning Talks section shows the 2021/2023/2024 edition dates
- [ ] Confirm the left "Contenido" sidebar lists all 17 sections including the 4 new ones
- [ ] Click each new sidebar entry and verify smooth-scroll navigation works
- [ ] Scroll through the page and verify scroll-spy highlights the correct section
- [ ] Check mobile view (sidebar is hidden, cards go borderless — should match existing sections)
- [ ] Check dark mode looks consistent with existing sections