### PR TITLE
feat(inscripciones): add search, sorting, wider columns, and summary cards

### DIFF
--- a/src/actions/events/get-event-registrations.ts
+++ b/src/actions/events/get-event-registrations.ts
@@ -1,0 +1,35 @@
+'use server';
+
+import prisma from '@/lib/prisma';
+
+export type EventRegistrationRow = {
+  id: string;
+  name: string;
+  email: string;
+  jobTitle: string | null;
+  enterprise: string | null;
+  career: string | null;
+  studyPlace: string | null;
+  cancelledAt: Date | null;
+  createdAt: Date;
+};
+
+export async function getEventRegistrations(eventId: string): Promise<EventRegistrationRow[]> {
+  const registrations = await prisma.eventRegistration.findMany({
+    where: { eventId },
+    include: { user: true },
+    orderBy: { createdAt: 'desc' },
+  });
+
+  return registrations.map((r) => ({
+    id: r.id,
+    name: r.user.name,
+    email: r.user.email,
+    jobTitle: r.user.jobTitle,
+    enterprise: r.user.enterprise,
+    career: r.user.career,
+    studyPlace: r.user.studyPlace,
+    cancelledAt: r.cancelledAt,
+    createdAt: r.createdAt,
+  }));
+}

--- a/src/app/(platform)/eventos/[id]/inscripciones/page.tsx
+++ b/src/app/(platform)/eventos/[id]/inscripciones/page.tsx
@@ -11,25 +11,16 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { Heading2 } from '@/components/ui/heading-2';
-import { ArrowLeft, Users } from 'lucide-react';
+import { ArrowLeft, Briefcase, GraduationCap, Users } from 'lucide-react';
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import prisma from '@/lib/prisma';
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
 import { fetchEvent } from '@/actions/events/fetch-event';
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
-import { Badge } from '@/components/ui/badge';
-import { DeleteRegistrationButton } from '@/components/events/delete-registration-button';
+import { getEventRegistrations } from '@/actions/events/get-event-registrations';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { LocalDateTime } from '@/components/ui/local-date-time';
+import { RegistrationsDataTable } from '@/components/events/registrations-data-table';
 
 const EventRegistrationsPage = async (props: { params: Promise<{ id: string }> }) => {
   const params = await props.params;
@@ -58,21 +49,17 @@ const EventRegistrationsPage = async (props: { params: Promise<{ id: string }> }
     redirect('/eventos');
   }
 
-  // Obtener todas las inscripciones con datos del usuario
-  const registrations = await prisma.eventRegistration.findMany({
-    where: {
-      eventId: id,
-    },
-    include: {
-      user: true,
-    },
-    orderBy: {
-      createdAt: 'desc',
-    },
-  });
+  // Obtener todas las inscripciones
+  const registrations = await getEventRegistrations(id);
 
   const activeRegistrations = registrations.filter((r) => r.cancelledAt === null);
   const cancelledRegistrations = registrations.filter((r) => r.cancelledAt !== null);
+
+  // Contar estudiantes y profesionales (solo inscripciones activas)
+  const studentsCount = activeRegistrations.filter((r) => r.career && r.studyPlace).length;
+  const professionalsCount = activeRegistrations.filter(
+    (r) => r.jobTitle && r.enterprise,
+  ).length;
 
   return (
     <>
@@ -114,101 +101,56 @@ const EventRegistrationsPage = async (props: { params: Promise<{ id: string }> }
             </div>
           </div>
 
+          {/* Tarjetas resumen */}
+          <div className="mb-6 grid gap-4 sm:grid-cols-3">
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Inscripciones activas</CardTitle>
+                <Users className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <p className="text-3xl font-bold">{activeRegistrations.length}</p>
+                <p className="text-xs text-muted-foreground">
+                  {cancelledRegistrations.length} cancelada
+                  {cancelledRegistrations.length !== 1 ? 's' : ''}
+                </p>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Estudiantes</CardTitle>
+                <GraduationCap className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <p className="text-3xl font-bold">{studentsCount}</p>
+                <p className="text-xs text-muted-foreground">con carrera y lugar de estudio</p>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium">Profesionales</CardTitle>
+                <Briefcase className="h-4 w-4 text-muted-foreground" />
+              </CardHeader>
+              <CardContent>
+                <p className="text-3xl font-bold">{professionalsCount}</p>
+                <p className="text-xs text-muted-foreground">con cargo y empresa</p>
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Tabla de inscripciones */}
           <Card className="border-2 border-transparent bg-gradient-to-br from-white to-gray-50 transition-all duration-300 hover:shadow-xl dark:border-neutral-800 dark:from-neutral-900 dark:to-neutral-800">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <Users className="h-5 w-5" />
-                Inscripciones ({registrations.length} total - {activeRegistrations.length} activas,{' '}
-                {cancelledRegistrations.length} canceladas)
+                Inscripciones ({registrations.length} total — {activeRegistrations.length}{' '}
+                activas, {cancelledRegistrations.length} canceladas)
               </CardTitle>
             </CardHeader>
             <CardContent>
-              {registrations.length === 0 ? (
-                <p className="py-8 text-center text-sm text-muted-foreground">
-                  Aún no hay inscripciones para este evento.
-                </p>
-              ) : (
-                <div className="rounded-md border">
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead>Nombre</TableHead>
-                        <TableHead>Email</TableHead>
-                        <TableHead>Información</TableHead>
-                        <TableHead>Estado</TableHead>
-                        <TableHead>Fecha de inscripción</TableHead>
-                        <TableHead className="text-right">Acciones</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {registrations.map((registration) => {
-                        const user = registration.user;
-                        const hasProfessionalData = user.jobTitle && user.enterprise;
-                        const hasStudentData = user.career && user.studyPlace;
-
-                        return (
-                          <TableRow
-                            key={registration.id}
-                            className={registration.cancelledAt ? 'opacity-60' : ''}
-                          >
-                            <TableCell className="font-medium">{user.name}</TableCell>
-                            <TableCell>{user.email}</TableCell>
-                            <TableCell>
-                              {hasProfessionalData ? (
-                                <div className="text-sm text-muted-foreground">
-                                  <Badge variant="outline" className="mb-1">
-                                    Profesional
-                                  </Badge>
-                                  <p>
-                                    <span className="font-medium">Trabaja:</span> {user.jobTitle}
-                                  </p>
-                                  <p>
-                                    <span className="font-medium">En:</span> {user.enterprise}
-                                  </p>
-                                </div>
-                              ) : hasStudentData ? (
-                                <div className="text-sm text-muted-foreground">
-                                  <Badge variant="outline" className="mb-1">
-                                    Estudiante
-                                  </Badge>
-                                  <p>
-                                    <span className="font-medium">Estudia:</span> {user.career}
-                                  </p>
-                                  <p>
-                                    <span className="font-medium">Dónde:</span> {user.studyPlace}
-                                  </p>
-                                </div>
-                              ) : (
-                                <span className="text-sm text-muted-foreground">
-                                  Sin información adicional
-                                </span>
-                              )}
-                            </TableCell>
-                            <TableCell>
-                              {registration.cancelledAt ? (
-                                <Badge variant="destructive">Cancelada</Badge>
-                              ) : (
-                                <Badge variant="default">Activa</Badge>
-                              )}
-                            </TableCell>
-                            <TableCell className="text-sm text-muted-foreground">
-                              <LocalDateTime date={registration.createdAt} />
-                            </TableCell>
-                            <TableCell className="text-right">
-                              {!registration.cancelledAt && (
-                                <DeleteRegistrationButton
-                                  registrationId={registration.id}
-                                  userName={user.name}
-                                />
-                              )}
-                            </TableCell>
-                          </TableRow>
-                        );
-                      })}
-                    </TableBody>
-                  </Table>
-                </div>
-              )}
+              <RegistrationsDataTable data={registrations} />
             </CardContent>
           </Card>
         </div>

--- a/src/components/events/registrations-columns.tsx
+++ b/src/components/events/registrations-columns.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { ColumnDef } from '@tanstack/react-table';
+import { ArrowUpDown } from 'lucide-react';
+
+import { EventRegistrationRow } from '@/actions/events/get-event-registrations';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { LocalDateTime } from '@/components/ui/local-date-time';
+import { DeleteRegistrationButton } from '@/components/events/delete-registration-button';
+
+function SortableHeader({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <Button variant="ghost" size="sm" className="-ml-3 gap-1" onClick={onClick}>
+      {label}
+      <ArrowUpDown className="h-3.5 w-3.5 text-muted-foreground" />
+    </Button>
+  );
+}
+
+export const registrationColumns: ColumnDef<EventRegistrationRow>[] = [
+  {
+    accessorKey: 'name',
+    meta: { className: 'min-w-[260px] whitespace-nowrap' },
+    header: ({ column }) => (
+      <SortableHeader
+        label="Nombre"
+        onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+      />
+    ),
+    cell: ({ getValue }) => <span className="font-medium">{getValue<string>()}</span>,
+  },
+  {
+    accessorKey: 'email',
+    meta: { className: 'min-w-[280px]' },
+    header: 'Email',
+    cell: ({ getValue }) => <span className="text-sm">{getValue<string>()}</span>,
+  },
+  {
+    id: 'info',
+    meta: { className: 'min-w-[320px]' },
+    header: 'Información',
+    enableSorting: false,
+    cell: ({ row }) => {
+      const { jobTitle, enterprise, career, studyPlace } = row.original;
+      const hasProfessionalData = jobTitle && enterprise;
+      const hasStudentData = career && studyPlace;
+
+      if (hasProfessionalData) {
+        return (
+          <div className="text-sm text-muted-foreground">
+            <Badge variant="outline" className="mb-1">
+              Profesional
+            </Badge>
+            <p>
+              <span className="font-medium">Trabaja:</span> {jobTitle}
+            </p>
+            <p>
+              <span className="font-medium">En:</span> {enterprise}
+            </p>
+          </div>
+        );
+      }
+
+      if (hasStudentData) {
+        return (
+          <div className="text-sm text-muted-foreground">
+            <Badge variant="outline" className="mb-1">
+              Estudiante
+            </Badge>
+            <p>
+              <span className="font-medium">Estudia:</span> {career}
+            </p>
+            <p>
+              <span className="font-medium">Dónde:</span> {studyPlace}
+            </p>
+          </div>
+        );
+      }
+
+      return <span className="text-sm text-muted-foreground">Sin información adicional</span>;
+    },
+  },
+  {
+    accessorKey: 'cancelledAt',
+    meta: { className: 'min-w-[120px]' },
+    header: 'Estado',
+    enableSorting: false,
+    cell: ({ getValue }) => {
+      const v = getValue<Date | null>();
+      return v ? (
+        <Badge variant="destructive">Cancelada</Badge>
+      ) : (
+        <Badge variant="default">Activa</Badge>
+      );
+    },
+  },
+  {
+    accessorKey: 'createdAt',
+    meta: { className: 'min-w-[200px]' },
+    header: ({ column }) => (
+      <SortableHeader
+        label="Fecha de inscripción"
+        onClick={() => column.toggleSorting(column.getIsSorted() === 'asc')}
+      />
+    ),
+    cell: ({ getValue }) => (
+      <span className="whitespace-nowrap text-sm text-muted-foreground">
+        <LocalDateTime date={getValue<Date>()} />
+      </span>
+    ),
+  },
+  {
+    id: 'actions',
+    meta: { className: 'text-right' },
+    header: () => <span className="block text-right">Acciones</span>,
+    enableSorting: false,
+    cell: ({ row }) => {
+      const { id, name, cancelledAt } = row.original;
+      if (cancelledAt) return null;
+      return (
+        <div className="flex justify-end">
+          <DeleteRegistrationButton registrationId={id} userName={name} />
+        </div>
+      );
+    },
+  },
+];

--- a/src/components/events/registrations-data-table.tsx
+++ b/src/components/events/registrations-data-table.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import {
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  SortingState,
+  useReactTable,
+} from '@tanstack/react-table';
+import { ChevronLeft, ChevronRight, Search, X } from 'lucide-react';
+import { useState } from 'react';
+
+import { EventRegistrationRow } from '@/actions/events/get-event-registrations';
+import { registrationColumns } from '@/components/events/registrations-columns';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+interface RegistrationsDataTableProps {
+  data: EventRegistrationRow[];
+}
+
+export function RegistrationsDataTable({ data }: RegistrationsDataTableProps) {
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [globalFilter, setGlobalFilter] = useState('');
+
+  const table = useReactTable({
+    data,
+    columns: registrationColumns,
+    state: { sorting, globalFilter },
+    onSortingChange: setSorting,
+    onGlobalFilterChange: setGlobalFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: { pagination: { pageSize: 100 } },
+  });
+
+  return (
+    <div className="space-y-3">
+      {/* Toolbar */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Buscar inscripción..."
+            value={globalFilter}
+            onChange={(e) => setGlobalFilter(e.target.value)}
+            className="pl-9"
+          />
+          {globalFilter && (
+            <button
+              onClick={() => setGlobalFilter('')}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+        <span className="shrink-0 text-sm text-muted-foreground">
+          {table.getFilteredRowModel().rows.length} de {data.length}
+        </span>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-md border">
+        <Table>
+          <TableHeader>
+            {table.getHeaderGroups().map((hg) => (
+              <TableRow key={hg.id}>
+                {hg.headers.map((header) => (
+                  <TableHead
+                    key={header.id}
+                    className={
+                      (header.column.columnDef.meta as { className?: string } | undefined)
+                        ?.className
+                    }
+                  >
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  className={row.original.cancelledAt ? 'opacity-60' : ''}
+                >
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell
+                      key={cell.id}
+                      className={
+                        (cell.column.columnDef.meta as { className?: string } | undefined)
+                          ?.className
+                      }
+                    >
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={registrationColumns.length}
+                  className="h-24 text-center text-muted-foreground"
+                >
+                  No se encontraron inscripciones.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          Página {table.getState().pagination.pageIndex + 1} de {table.getPageCount()}
+        </p>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            <ChevronLeft className="h-4 w-4" />
+            Anterior
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            Siguiente
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Replace the static inscripciones table with a TanStack-powered data table (global keyword search, sortable Nombre and Fecha de inscripción columns, horizontal scroll with wide `min-w-*` columns)
- Add three summary cards at the top: **Inscripciones activas**, **Estudiantes**, **Profesionales** (active-only counts using existing classification logic)
- Extract the Prisma query into `src/actions/events/get-event-registrations.ts` following the `/usuarios` server action pattern
- New column defs in `src/components/events/registrations-columns.tsx` and table wrapper in `src/components/events/registrations-data-table.tsx`

## Test plan

- [ ] Log in as ADMIN and visit `/eventos/<id>/inscripciones` for an event with registrations
- [ ] Verify three summary cards appear with correct counts (students/professionals count active only)
- [ ] Verify columns are wider and the table scrolls horizontally when needed
- [ ] Type in the search box — rows should filter across name/email
- [ ] Click Nombre and Fecha de inscripción headers — rows should sort asc/desc
- [ ] Confirm delete button works on active rows and is absent on cancelled rows (opacity-60)