### PR TITLE
feat(sidebar): move Recursos first and Redes last in Comunidad section

### DIFF
--- a/src/components/ui/app-sidebar.tsx
+++ b/src/components/ui/app-sidebar.tsx
@@ -149,6 +149,11 @@ const socialNetworks = [
 const getComunidadItems = () => {
   return [
     {
+      title: 'Recursos',
+      icon: Library,
+      items: getRecursosSubItems(),
+    },
+    {
       title: 'Historia',
       url: '/historia',
       icon: ScrollText,
@@ -162,11 +167,6 @@ const getComunidadItems = () => {
       title: 'Redes',
       icon: Share2,
       items: socialNetworks.map(({ name, url }) => ({ title: name, url })),
-    },
-    {
-      title: 'Recursos',
-      icon: Library,
-      items: getRecursosSubItems(),
     },
   ];
 };


### PR DESCRIPTION
## Summary
- Moves "Recursos" to the top of the Comunidad sidebar section
- Moves "Redes" to the bottom of the Comunidad sidebar section