### PR TITLE
feat(cursos): add new courses and unified grid layout

### DIFF
--- a/src/app/(platform)/cursos/courses.ts
+++ b/src/app/(platform)/cursos/courses.ts
@@ -115,6 +115,18 @@ export const externalCourses: Array<Course> = [
     hours: 7,
   },
   {
+    name: 'Docker',
+    id: 'docker',
+    description:
+      'Docker te permite empaquetar tus aplicaciones en contenedores para que corran igual en cualquier máquina, simplificando el desarrollo y el despliegue. En este curso completo desde cero vas a aprender la teoría detrás de los contenedores, la instalación de Docker, los comandos para manejar imágenes y contenedores, cómo conectarte a los contenedores, Docker Compose para orquestar varios servicios, el uso de volúmenes para persistir datos, y la configuración de ambientes con hot reload para desarrollo. Ideal para quienes quieren incorporar Docker a su flujo de trabajo desde lo más básico hasta dejar una aplicación lista para correr.',
+    youtubeUrls: ['https://www.youtube.com/embed/4Dko5W96WHg'],
+    teachedBy: 'HolaMundo',
+    acceptDonations: false,
+    isMadeByCommunity: false,
+    date: new Date('2026-01-01'),
+    hours: 1,
+  },
+  {
     name: 'Hermes Agent',
     id: 'hermes-agent',
     description:

--- a/src/app/(platform)/cursos/courses.ts
+++ b/src/app/(platform)/cursos/courses.ts
@@ -115,6 +115,18 @@ export const externalCourses: Array<Course> = [
     hours: 7,
   },
   {
+    name: 'Hermes Agent',
+    id: 'hermes-agent',
+    description:
+      'Hermes Agent es uno de los agentes de IA open source más avanzados y fáciles de usar del momento: tiene memoria persistente, crea sus propias skills, se comunica por Telegram y WhatsApp y puede trabajar de forma autónoma 24/7. En este tutorial vas a aprender a instalarlo, configurarlo y usarlo de forma profesional en un servidor VPS (Hostinger): la configuración completa con OpenAI y Telegram, el Dashboard Web y el Canvas para manejar múltiples agentes, las tareas programadas con Cron Jobs, la generación de proyectos completos (frontend y backend), la integración con GitHub CLI, los perfiles personalizados y Skills, el acceso seguro desde cualquier lugar con Tailscale, y los comandos y trucos más útiles. Ideal para quienes quieren su propio asistente de IA personal que realmente aprende y trabaja por sí solo.',
+    youtubeUrls: ['https://www.youtube.com/embed/gpbEfTQ1kLU'],
+    teachedBy: 'Fazt',
+    acceptDonations: false,
+    isMadeByCommunity: false,
+    date: new Date('2026-01-01'),
+    hours: 1,
+  },
+  {
     name: 'Cursor',
     id: 'cursor',
     description:

--- a/src/app/(platform)/cursos/courses.ts
+++ b/src/app/(platform)/cursos/courses.ts
@@ -115,6 +115,18 @@ export const externalCourses: Array<Course> = [
     hours: 7,
   },
   {
+    name: 'Cursor',
+    id: 'cursor',
+    description:
+      'Cursor es uno de los editores de código con inteligencia artificial más potentes del momento. En este curso completo vas a aprender a usarlo desde cero hasta un nivel avanzado: qué es y en qué se diferencia de VS Code, instalación y configuración inicial, el chat inteligente y el autocompletado avanzado, el Agent Mode vs el Plan Mode, cómo crear proyectos completos solo con prompts, el uso de distintos modelos de IA (Claude, GPT, Gemini, Auto Mode), los MCPs para conectar Cursor con otras herramientas, el testing automático con IA, las reglas y comandos personalizados, y cuándo conviene pagar el plan Pro. Una guía actualizada para integrar la IA en tu flujo de trabajo, tanto si recién empezás como si ya programás.',
+    youtubeUrls: ['https://www.youtube.com/embed/bMmVZFd7HA4'],
+    teachedBy: 'Fazt',
+    acceptDonations: false,
+    isMadeByCommunity: false,
+    date: new Date('2026-01-01'),
+    hours: 1,
+  },
+  {
     name: 'Claude Code',
     id: 'claude-code',
     description:

--- a/src/app/(platform)/cursos/courses.ts
+++ b/src/app/(platform)/cursos/courses.ts
@@ -114,6 +114,18 @@ export const externalCourses: Array<Course> = [
     date: new Date('2024-01-12'),
     hours: 7,
   },
+  {
+    name: 'Claude Code',
+    id: 'claude-code',
+    description:
+      'El curso más completo de Claude Code en español. Vas a pasar de no tener nada instalado a construir y desplegar proyectos reales con IA, sin necesidad de saber programar. Cubre el ecosistema de Claude (Chat, Cowork y Claude Code), la instalación desde cero en Mac y Windows, el setup de VS Code, el archivo CLAUDE.md, los Skills, las conexiones MCP, el manejo de contexto y tokens, los hooks, y el deploy a internet con Vercel. Todo con proyectos en vivo: dashboards, landing pages, un Ad Manager con Meta Ads y automatizaciones con n8n.',
+    youtubeUrls: ['https://www.youtube.com/embed/73eFWU-edO4'],
+    teachedBy: 'Benjamín Cordero',
+    acceptDonations: false,
+    isMadeByCommunity: false,
+    date: new Date('2026-01-01'),
+    hours: 3,
+  },
 ];
 
 export const getCourseById = (courseId: string) =>

--- a/src/app/(platform)/cursos/courses.ts
+++ b/src/app/(platform)/cursos/courses.ts
@@ -162,6 +162,20 @@ export const externalCourses: Array<Course> = [
     date: new Date('2026-01-01'),
     hours: 3,
   },
+  {
+    name: 'C++',
+    id: 'cpp',
+    description:
+      'C++ es uno de los lenguajes de programación más potentes y utilizados del mundo, presente en videojuegos, sistemas operativos, navegadores y aplicaciones de alto rendimiento. En este curso completo en español vas a aprender desde cero: la instalación y configuración del entorno, los tipos de datos y variables, los operadores, las estructuras de control (condicionales y bucles), las funciones, los arreglos y matrices, los punteros, la memoria dinámica, la programación orientada a objetos (clases, objetos, herencia, polimorfismo) y mucho más. Una guía ideal para quienes quieren dominar uno de los lenguajes fundamentales de la programación.',
+    youtubeUrls: [
+      'https://www.youtube.com/embed/videoseries?list=PLWtYZ2ejMVJlUu1rEHLC0i_oibctkl0Vh',
+    ],
+    teachedBy: 'Programación ATS',
+    acceptDonations: false,
+    isMadeByCommunity: false,
+    date: new Date('2026-01-01'),
+    hours: 20,
+  },
 ];
 
 export const getCourseById = (courseId: string) =>

--- a/src/app/(platform)/cursos/page.tsx
+++ b/src/app/(platform)/cursos/page.tsx
@@ -2,7 +2,6 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Heading2 } from '@/components/ui/heading-2';
-import { Heading3 } from '@/components/ui/heading-3';
 import {
   Breadcrumb,
   BreadcrumbList,
@@ -17,6 +16,10 @@ import { Laptop, TvMinimalPlay } from 'lucide-react';
 import Link from 'next/link';
 import { communityCourses, Course, externalCourses } from './courses';
 import type { Metadata } from 'next';
+
+const allCourses = [...communityCourses, ...externalCourses].sort((a, b) =>
+  a.name.localeCompare(b.name, 'es', { sensitivity: 'base' }),
+);
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://programaconnosotros.com';
 
@@ -55,12 +58,19 @@ const CourseCard = ({ course }: { course: Course }) => {
   return (
     <Card className="flex flex-col justify-between border-2 border-transparent bg-gradient-to-br from-white to-gray-50 transition-all duration-300 hover:scale-[1.02] hover:shadow-xl dark:border-neutral-800 dark:from-neutral-900 dark:to-neutral-800 md:min-h-[320px]">
       <div>
-        <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <CardHeader className="flex flex-row items-center justify-between gap-2 pb-2">
           <CardTitle>{course.name}</CardTitle>
 
-          <Badge variant="outline">
-            {course.hours} {course.hours === 1 ? 'hora' : 'horas'}
-          </Badge>
+          <div className="flex shrink-0 flex-col items-end gap-1">
+            {course.isMadeByCommunity && (
+              <Badge className="border-pcnPurple/30 bg-pcnPurple/10 text-pcnPurple dark:border-pcnGreen/50 dark:bg-pcnGreen/10 dark:text-pcnGreen">
+                Made in PCN
+              </Badge>
+            )}
+            <Badge variant="outline">
+              {course.hours} {course.hours === 1 ? 'hora' : 'horas'}
+            </Badge>
+          </div>
         </CardHeader>
 
         <CardContent className="flex flex-1 flex-col text-sm">{course.description}</CardContent>
@@ -106,16 +116,8 @@ const Courses = () => (
           </div>
         </div>
 
-        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {communityCourses.map((course) => (
-            <CourseCard key={course.id} course={course} />
-          ))}
-        </div>
-
-        <Heading3 className="mt-12">Cursos externos recomendados</Heading3>
-
-        <div className="mb-14 mt-4 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-          {externalCourses.map((course) => (
+        <div className="mb-14 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {allCourses.map((course) => (
             <CourseCard key={course.id} course={course} />
           ))}
         </div>


### PR DESCRIPTION
## Summary

- Add 5 new courses: C++ (Programación ATS), Docker (HolaMundo), Hermes Agent (Fazt), Cursor (Fazt), Claude Code (Benjamín Cordero)
- Unify all courses into a single grid with a "Made in PCN" badge for community-created courses

## Test plan

- [ ] Visit `/cursos` and verify all new courses appear in the grid
- [ ] Verify "Made in PCN" badge displays correctly on PCN-created courses
- [ ] Confirm external courses (Docker, Hermes Agent, Cursor, Claude Code) display without the badge