### PR TITLE
feat(cursos): add Next.js interactive website course

### DIFF
--- a/src/app/(platform)/cursos/[courseId]/page.tsx
+++ b/src/app/(platform)/cursos/[courseId]/page.tsx
@@ -9,6 +9,7 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import {
   Carousel,
   CarouselContent,
@@ -18,6 +19,7 @@ import {
 } from '@/components/ui/carousel';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Heading2 } from '@/components/ui/heading-2';
+import { ExternalLink } from 'lucide-react';
 import { getCourseById } from '../courses';
 import type { Metadata } from 'next';
 
@@ -100,33 +102,44 @@ const Course = async (props: { params: Promise<{ courseId: string }> }) => {
             <Heading2 className="m-0">{course.name}</Heading2>
           </div>
 
-          <div className={`mt-6${course.youtubeUrls.length > 1 ? ' px-12' : ''}`}>
-            <Carousel>
-              <CarouselContent>
-                {course.youtubeUrls.map((classUrl) => (
-                  <CarouselItem key={classUrl}>
-                    <div className="w-full" style={{ aspectRatio: '16/9' }}>
-                      <iframe
-                        className="h-full w-full"
-                        src={classUrl}
-                        title="YouTube video player"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                        referrerPolicy="strict-origin-when-cross-origin"
-                        allowFullScreen
-                      />
-                    </div>
-                  </CarouselItem>
-                ))}
-              </CarouselContent>
+          {course.websiteUrl ? (
+            <div className="mt-6">
+              <a href={course.websiteUrl} target="_blank" rel="noopener noreferrer">
+                <Button className="flex flex-row items-center gap-2">
+                  Ir al curso
+                  <ExternalLink className="h-5 w-5" />
+                </Button>
+              </a>
+            </div>
+          ) : (
+            <div className={`mt-6${course.youtubeUrls && course.youtubeUrls.length > 1 ? ' px-12' : ''}`}>
+              <Carousel>
+                <CarouselContent>
+                  {course.youtubeUrls?.map((classUrl) => (
+                    <CarouselItem key={classUrl}>
+                      <div className="w-full" style={{ aspectRatio: '16/9' }}>
+                        <iframe
+                          className="h-full w-full"
+                          src={classUrl}
+                          title="YouTube video player"
+                          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                          referrerPolicy="strict-origin-when-cross-origin"
+                          allowFullScreen
+                        />
+                      </div>
+                    </CarouselItem>
+                  ))}
+                </CarouselContent>
 
-              {course.youtubeUrls.length > 1 && (
-                <>
-                  <CarouselPrevious />
-                  <CarouselNext />
-                </>
-              )}
-            </Carousel>
-          </div>
+                {course.youtubeUrls && course.youtubeUrls.length > 1 && (
+                  <>
+                    <CarouselPrevious />
+                    <CarouselNext />
+                  </>
+                )}
+              </Carousel>
+            </div>
+          )}
 
           <Card className="mt-6">
             <CardHeader className="flex flex-row items-center justify-between gap-2 pb-2">
@@ -138,11 +151,13 @@ const Course = async (props: { params: Promise<{ courseId: string }> }) => {
                   </Badge>
                 )}
               </div>
-              <div className="shrink-0">
-                <Badge variant="outline">
-                  {course.hours} {course.hours === 1 ? 'hora' : 'horas'}
-                </Badge>
-              </div>
+              {!course.websiteUrl && course.hours !== undefined && (
+                <div className="shrink-0">
+                  <Badge variant="outline">
+                    {course.hours} {course.hours === 1 ? 'hora' : 'horas'}
+                  </Badge>
+                </div>
+              )}
             </CardHeader>
             <CardContent className="text-sm">{course.description}</CardContent>
             <CardFooter className="text-sm text-muted-foreground">
@@ -150,7 +165,7 @@ const Course = async (props: { params: Promise<{ courseId: string }> }) => {
             </CardFooter>
           </Card>
 
-          {!course.isMadeByCommunity && (
+          {!course.isMadeByCommunity && !course.websiteUrl && (
             <p className="mt-4 text-sm text-muted-foreground">
               Este curso no fue creado por un miembro de la comunidad, fue publicado gratuitamente
               en YouTube y nos parece de muy buena calidad, por lo cual lo recomendamos. Embebemos

--- a/src/app/(platform)/cursos/courses.ts
+++ b/src/app/(platform)/cursos/courses.ts
@@ -2,12 +2,13 @@ export type Course = {
   id: string;
   name: string;
   description: string;
-  youtubeUrls: Array<string>;
+  youtubeUrls?: Array<string>;
+  websiteUrl?: string;
   teachedBy: string;
   acceptDonations: boolean;
   isMadeByCommunity: boolean;
   date: Date;
-  hours: number;
+  hours?: number;
 };
 
 export const communityCourses: Array<Course> = [
@@ -161,6 +162,17 @@ export const externalCourses: Array<Course> = [
     isMadeByCommunity: false,
     date: new Date('2026-01-01'),
     hours: 3,
+  },
+  {
+    name: 'Next.js',
+    id: 'nextjs',
+    description:
+      'Aprendé Next.js, el framework de React para construir aplicaciones web full-stack. Es el curso oficial e interactivo: vas leyendo y practicando a tu propio ritmo mientras construís una aplicación real, cubriendo routing, renderizado, obtención de datos y más.',
+    websiteUrl: 'https://nextjs.org/learn',
+    teachedBy: 'Vercel',
+    acceptDonations: false,
+    isMadeByCommunity: false,
+    date: new Date('2026-01-01'),
   },
 ];
 

--- a/src/app/(platform)/cursos/page.tsx
+++ b/src/app/(platform)/cursos/page.tsx
@@ -118,7 +118,7 @@ const Courses = () => (
           </div>
         </div>
 
-        <div className="mb-14 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <div className="mb-14 grid grid-cols-1 gap-4 lg:grid-cols-2 xl:grid-cols-3">
           {allCourses.map((course) => (
             <CourseCard key={course.id} course={course} />
           ))}

--- a/src/app/(platform)/cursos/page.tsx
+++ b/src/app/(platform)/cursos/page.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/breadcrumb';
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
-import { Laptop, TvMinimalPlay } from 'lucide-react';
+import { ExternalLink, Laptop, TvMinimalPlay } from 'lucide-react';
 import Link from 'next/link';
 import { communityCourses, Course, externalCourses } from './courses';
 import type { Metadata } from 'next';
@@ -46,14 +46,22 @@ export const metadata: Metadata = {
 };
 
 const CourseCard = ({ course }: { course: Course }) => {
-  const ViewButton = () => (
-    <Link href={`/cursos/${course.id}`} className="w-full">
-      <Button className="flex w-full flex-row items-center gap-2">
-        Ver curso
-        <TvMinimalPlay className="h-5 w-5" />
-      </Button>
-    </Link>
-  );
+  const ViewButton = () =>
+    course.websiteUrl ? (
+      <a href={course.websiteUrl} target="_blank" rel="noopener noreferrer" className="w-full">
+        <Button className="flex w-full flex-row items-center gap-2">
+          Ver curso
+          <ExternalLink className="h-5 w-5" />
+        </Button>
+      </a>
+    ) : (
+      <Link href={`/cursos/${course.id}`} className="w-full">
+        <Button className="flex w-full flex-row items-center gap-2">
+          Ver curso
+          <TvMinimalPlay className="h-5 w-5" />
+        </Button>
+      </Link>
+    );
 
   return (
     <Card className="flex flex-col justify-between border-2 border-transparent bg-gradient-to-br from-white to-gray-50 transition-all duration-300 hover:scale-[1.02] hover:shadow-xl dark:border-neutral-800 dark:from-neutral-900 dark:to-neutral-800 md:min-h-[320px]">
@@ -69,9 +77,13 @@ const CourseCard = ({ course }: { course: Course }) => {
           </div>
 
           <div className="shrink-0">
-            <Badge variant="outline">
-              {course.hours} {course.hours === 1 ? 'hora' : 'horas'}
-            </Badge>
+            {course.websiteUrl ? (
+              <Badge variant="outline">Interactivo</Badge>
+            ) : (
+              <Badge variant="outline">
+                {course.hours} {course.hours === 1 ? 'hora' : 'horas'}
+              </Badge>
+            )}
           </div>
         </CardHeader>
 


### PR DESCRIPTION
## Summary

- Adds the official [Next.js Learn](https://nextjs.org/learn) course as the first website-based (non-video) course
- Extends the `Course` type with an optional `websiteUrl` field and makes `youtubeUrls`/`hours` optional to support this format
- Course card shows an **"Interactivo"** badge and links directly to the external site in a new tab (instead of opening a detail page)
- The detail page gracefully handles website courses: shows an "Ir al curso" button instead of a broken video carousel, and hides the YouTube-only disclaimer

## Test plan

- [ ] Visit `/cursos` — Next.js card appears alphabetically, shows "Interactivo" badge and "Curso dictado por Vercel"
- [ ] Click "Ver curso" on the Next.js card → opens `https://nextjs.org/learn` in a new tab
- [ ] Confirm existing video courses are unchanged: hours badge intact, "Ver curso" navigates to their detail page with the YouTube carousel
- [ ] Visit `/cursos/nextjs` directly — renders description card and "Ir al curso" button without errors, no carousel, no YouTube disclaimer