### PR TITLE
feat(lectura): add 9 articles and sort by publish date

### DIFF
--- a/src/app/(platform)/lectura/articles.ts
+++ b/src/app/(platform)/lectura/articles.ts
@@ -7,7 +7,7 @@ export interface Article {
   description: string;
   url: string;
   avatar: string;
-  year?: number;
+  date: string; // ISO YYYY-MM-DD
 }
 
 export const articles: Article[] = [
@@ -21,7 +21,7 @@ export const articles: Article[] = [
       'Loop engineering reemplaza los prompts manuales con sistemas autónomos que iteran hasta completar objetivos, cambiando cómo trabajamos con agentes de código.',
     url: 'https://addyosmani.com/blog/loop-engineering/',
     avatar: 'https://github.com/addyosmani.png?size=128',
-    year: 2026,
+    date: '2026-06-07',
   },
   {
     id: '2',
@@ -33,7 +33,7 @@ export const articles: Article[] = [
       'Explora cómo la arquitectura que rodea a un modelo de IA (el "harness") es tan importante como el modelo mismo para construir agentes de código efectivos.',
     url: 'https://addyosmani.com/blog/agent-harness-engineering/',
     avatar: 'https://github.com/addyosmani.png?size=128',
-    year: 2026,
+    date: '2026-04-19',
   },
   {
     id: '3',
@@ -45,6 +45,114 @@ export const articles: Article[] = [
       'La infraestructura agéntica permite que agentes de IA desplieguen, construyan y ejecuten software de forma autónoma, transformando cómo operan los sistemas modernos.',
     url: 'https://vercel.com/blog/agentic-infrastructure',
     avatar: 'https://github.com/tomocchino.png?size=128',
-    year: 2026,
+    date: '2026-04-09',
   },
-].sort((a, b) => a.title.localeCompare(b.title, 'es', { sensitivity: 'base' }));
+  {
+    id: '4',
+    title: "Don't Outsource the Learning",
+    author: 'Addy Osmani',
+    source: 'addyosmani.com',
+    category: 'Programación',
+    description:
+      'Delegar tareas a la IA sin aprender activamente genera deuda cognitiva: se gana velocidad a corto plazo pero se erosiona la comprensión profunda necesaria para crecer como ingeniero.',
+    url: 'https://addyosmani.com/blog/dont-outsource-learning/',
+    avatar: 'https://github.com/addyosmani.png?size=128',
+    date: '2026-05-16',
+  },
+  {
+    id: '5',
+    title: 'handoff: Move Context Between Agent Sessions',
+    author: 'Matt Pocock',
+    source: 'aihero.dev',
+    category: 'Programación',
+    description:
+      'Skill que permite trasladar solo el contexto relevante de una sesión de agente a otra, manteniendo cada sesión enfocada y evitando la contaminación de contexto.',
+    url: 'https://www.aihero.dev/skills-handoff',
+    avatar: 'https://github.com/mattpocock.png?size=128',
+    date: '2026-05-13',
+  },
+  {
+    id: '6',
+    title: 'Agent Skills',
+    author: 'Addy Osmani',
+    source: 'addyosmani.com',
+    category: 'Programación',
+    description:
+      'Un conjunto de workflows que cubren las fases del ciclo de vida del software (Define, Plan, Build, Verify, Review, Ship) para que los agentes de código no salteen las prácticas de ingeniería que aseguran calidad.',
+    url: 'https://addyosmani.com/blog/agent-skills/',
+    avatar: 'https://github.com/addyosmani.png?size=128',
+    date: '2026-05-03',
+  },
+  {
+    id: '7',
+    title: 'tdd: Red, Green, Refactor for Agentic Coding',
+    author: 'Matt Pocock',
+    source: 'aihero.dev',
+    category: 'Programación',
+    description:
+      'Skill que guía a un agente de código por el ciclo red-green-refactor del TDD, verificando comportamiento a través de interfaces públicas en lugar de detalles de implementación.',
+    url: 'https://www.aihero.dev/skills-tdd',
+    avatar: 'https://github.com/mattpocock.png?size=128',
+    date: '2026-04-27',
+  },
+  {
+    id: '8',
+    title: 'My 7 Phases Of AI Development',
+    author: 'Matt Pocock',
+    source: 'aihero.dev',
+    category: 'Programación',
+    description:
+      'Un framework de siete fases (idea, investigación, prototipo, PRD, planificación, ejecución y QA) que describe el patrón común en workflows exitosos de desarrollo asistido por IA.',
+    url: 'https://www.aihero.dev/my-7-phases-of-ai-development',
+    avatar: 'https://github.com/mattpocock.png?size=128',
+    date: '2026-03-16',
+  },
+  {
+    id: '9',
+    title: 'Comprehension Debt',
+    author: 'Addy Osmani',
+    source: 'addyosmani.com',
+    category: 'Programación',
+    description:
+      'La IA genera código más rápido de lo que los ingenieros pueden comprenderlo, creando una "deuda de comprensión" que las métricas tradicionales no capturan y que puede tener graves consecuencias.',
+    url: 'https://addyosmani.com/blog/comprehension-debt/',
+    avatar: 'https://github.com/addyosmani.png?size=128',
+    date: '2026-03-14',
+  },
+  {
+    id: '10',
+    title: 'The Factory Model',
+    author: 'Addy Osmani',
+    source: 'addyosmani.com',
+    category: 'Arquitectura',
+    description:
+      'Los agentes de código representan un cambio de abstracción: el desarrollador ya no escribe código directamente sino que orquesta sistemas que lo generan, elevando el pensamiento sistémico y el juicio arquitectónico.',
+    url: 'https://addyosmani.com/blog/factory-model/',
+    avatar: 'https://github.com/addyosmani.png?size=128',
+    date: '2026-02-25',
+  },
+  {
+    id: '11',
+    title: 'Agent-native Architectures',
+    author: 'Every',
+    source: 'every.to',
+    category: 'Arquitectura',
+    description:
+      'Una guía para construir aplicaciones donde los agentes son ciudadanos de primera clase, cubriendo los patrones de diseño que hacen que los sistemas funcionen de forma confiable con IA autónoma.',
+    url: 'https://every.to/guides/agent-native',
+    avatar: 'https://github.com/everyinc.png?size=128',
+    date: '2026-01-17',
+  },
+  {
+    id: '12',
+    title: 'The Next Two Years of Software Engineering',
+    author: 'Addy Osmani',
+    source: 'addyosmani.com',
+    category: 'Programación',
+    description:
+      'Una visión de cómo la IA transformará la ingeniería de software en los próximos dos años: nuevos roles, nuevas habilidades críticas y qué fundamentos seguirán siendo irremplazables.',
+    url: 'https://addyosmani.com/blog/next-two-years/',
+    avatar: 'https://github.com/addyosmani.png?size=128',
+    date: '2026-01-05',
+  },
+].sort((a, b) => b.date.localeCompare(a.date));

--- a/src/app/(platform)/lectura/page.tsx
+++ b/src/app/(platform)/lectura/page.tsx
@@ -351,6 +351,14 @@ const categoryStyles: Record<string, string> = {
 };
 const defaultCategoryStyle = 'bg-secondary text-secondary-foreground';
 
+const formatArticleDate = (iso: string) =>
+  new Date(iso).toLocaleDateString('es-ES', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+
 const ReadingPage = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('Todas las categorías');
@@ -557,8 +565,7 @@ const ReadingPage = () => {
                             <div>
                               <p className="text-sm font-semibold leading-none">{article.author}</p>
                               <p className="text-xs text-muted-foreground">
-                                {article.source}
-                                {article.year && ` · ${article.year}`}
+                                {article.source} · {formatArticleDate(article.date)}
                               </p>
                             </div>
                           </div>


### PR DESCRIPTION
## Summary

- Add 9 new articles to the **Artículos** tab covering AI-assisted development topics (Addy Osmani, Matt Pocock/aihero.dev, Every)
- Replace the optional `year` field with a required ISO `date` field on the `Article` interface; update existing 3 articles with their actual publish dates
- Change article sort from alphabetical-by-title to newest-first by publish date
- Display the formatted publish date (es-ES locale) next to each article's source domain on the card

## New articles added

| Title | Author | Date |
|---|---|---|
| Don't Outsource the Learning | Addy Osmani | 2026-05-16 |
| handoff: Move Context Between Agent Sessions | Matt Pocock | 2026-05-13 |
| Agent Skills | Addy Osmani | 2026-05-03 |
| tdd: Red, Green, Refactor for Agentic Coding | Matt Pocock | 2026-04-27 |
| My 7 Phases Of AI Development | Matt Pocock | 2026-03-16 |
| Comprehension Debt | Addy Osmani | 2026-03-14 |
| The Factory Model | Addy Osmani | 2026-02-25 |
| Agent-native Architectures | Every | 2026-01-17 |
| The Next Two Years of Software Engineering | Addy Osmani | 2026-01-05 |

## Test plan

- [ ] Open `/lectura` → **Artículos** tab: 12 cards, ordered newest → oldest
- [ ] Each card shows `source · <date>` (e.g. `aihero.dev · 13 may 2026`)
- [ ] **Libros** tab still works: alphabetical, books unaffected
- [ ] Category filter and search work on articles tab
- [ ] All article links open to the correct URLs