### PR TITLE
feat(preguntas-frecuentes): replace accordion with always-expanded card grid

### DIFF
--- a/src/app/(platform)/preguntas-frecuentes/loading.tsx
+++ b/src/app/(platform)/preguntas-frecuentes/loading.tsx
@@ -1,7 +1,7 @@
 import {
   PageHeaderSkeleton,
   TitleRowSkeleton,
-  AccordionSkeleton,
+  CardListSkeleton,
 } from '@/components/skeletons/page-skeletons';
 
 export default function Loading() {
@@ -11,7 +11,7 @@ export default function Loading() {
       <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
         <div className="mt-4">
           <TitleRowSkeleton />
-          <AccordionSkeleton rows={8} />
+          <CardListSkeleton variant="grid" count={8} />
         </div>
       </div>
     </>

--- a/src/app/(platform)/preguntas-frecuentes/page.tsx
+++ b/src/app/(platform)/preguntas-frecuentes/page.tsx
@@ -10,12 +10,7 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { HelpCircle } from 'lucide-react';
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from '@/components/ui/accordion';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import type { Metadata } from 'next';
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://programaconnosotros.com';
@@ -120,17 +115,20 @@ const FAQPage = async () => {
             </div>
           </div>
 
-          <div className="mb-14 max-w-3xl">
-            <Accordion type="single" collapsible className="w-full">
-              {faqs.map((faq, index) => (
-                <AccordionItem key={index} value={`item-${index}`}>
-                  <AccordionTrigger className="text-left">{faq.question}</AccordionTrigger>
-                  <AccordionContent className="text-muted-foreground">
-                    {faq.answer}
-                  </AccordionContent>
-                </AccordionItem>
-              ))}
-            </Accordion>
+          <div className="mb-14 grid grid-cols-1 gap-4 md:grid-cols-2">
+            {faqs.map((faq, index) => (
+              <Card
+                key={index}
+                className="transition-colors hover:border-pcnPurple/40 dark:hover:border-pcnGreen/40"
+              >
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-base font-semibold">{faq.question}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-sm leading-relaxed text-muted-foreground">{faq.answer}</p>
+                </CardContent>
+              </Card>
+            ))}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Replaces the single-column collapsible accordion with a responsive 2-column card grid
- Each FAQ card is always expanded — question as card title, answer fully visible in card body
- Cards have a brand-accented hover border (`pcnPurple` / `pcnGreen`) consistent with the page header styling
- Loading skeleton updated from `AccordionSkeleton` to `CardListSkeleton variant="grid"` to match the new layout

## Test plan

- [ ] Navigate to `/preguntas-frecuentes` and confirm 8 FAQ cards render in a 2-column grid
- [ ] Resize to mobile — confirm grid collapses to a single column
- [ ] Hover cards — confirm brand-colored border appears
- [ ] Toggle dark mode — confirm `pcnGreen` hover border and card colors render correctly
- [ ] Hard-reload with throttled network — confirm loading skeleton shows a card grid