### PR TITLE
feat(series-y-peliculas): pin featured titles to top of grid

### DIFF
--- a/src/app/(platform)/series-y-peliculas/page.tsx
+++ b/src/app/(platform)/series-y-peliculas/page.tsx
@@ -38,6 +38,15 @@ interface Title {
   poster: string;
 }
 
+const featuredOrder = [
+  'Silicon Valley',
+  'Mr. Robot',
+  'The Social Network',
+  'Jobs',
+  'Snowden',
+  'The Imitation Game',
+];
+
 const titles: Title[] = [
   {
     id: '1',
@@ -226,7 +235,14 @@ const titles: Title[] = [
     year: 2022,
     poster: '/series-y-peliculas/we-crashed.jpg',
   },
-].sort((a, b) => a.title.localeCompare(b.title, 'es', { sensitivity: 'base' })) as Title[];
+].sort((a, b) => {
+  const aIndex = featuredOrder.indexOf(a.title);
+  const bIndex = featuredOrder.indexOf(b.title);
+  if (aIndex !== -1 || bIndex !== -1) {
+    return (aIndex === -1 ? Infinity : aIndex) - (bIndex === -1 ? Infinity : bIndex);
+  }
+  return a.title.localeCompare(b.title, 'es', { sensitivity: 'base' });
+}) as Title[];
 
 const genres = ['Todos los géneros', ...Array.from(new Set(titles.map((t) => t.genre)))];
 


### PR DESCRIPTION
## Summary
- Pins 6 titles to the top of the /series-y-peliculas page in the requested order: Silicon Valley, Mr. Robot, The Social Network, Jobs, Snowden, The Imitation Game
- All remaining titles continue to appear alphabetically after the featured ones
- Search and genre filters preserve the featured-first ordering

## Test plan
- [ ] Open `/series-y-peliculas` and confirm the first 6 cards match the specified order
- [ ] Confirm the rest of the grid is still alphabetically sorted
- [ ] Confirm search and genre filters still work correctly