### PR TITLE
feat(cursos): add Patterns.dev as external interactive course

### DIFF
--- a/src/app/(platform)/cursos/courses.ts
+++ b/src/app/(platform)/cursos/courses.ts
@@ -174,6 +174,17 @@ export const externalCourses: Array<Course> = [
     isMadeByCommunity: false,
     date: new Date('2026-01-01'),
   },
+  {
+    name: 'Patterns.dev',
+    id: 'patterns-dev',
+    description:
+      'Patterns.dev es una guía gratuita sobre patrones de diseño y optimización del rendimiento para construir aplicaciones web modernas. Cubre patrones de diseño clásicos, patrones de renderizado y de rendimiento aplicados a JavaScript vanilla y React, ideal para mejorar la arquitectura de tus aplicaciones.',
+    websiteUrl: 'https://www.patterns.dev/',
+    teachedBy: 'Lydia Hallie & Addy Osmani',
+    acceptDonations: false,
+    isMadeByCommunity: false,
+    date: new Date('2026-01-01'),
+  },
 ];
 
 export const getCourseById = (courseId: string) =>


### PR DESCRIPTION
## Summary

- Adds [Patterns.dev](https://www.patterns.dev/) to the `/cursos` page as an external interactive course
- Follows the existing `websiteUrl` pattern (same as Next.js entry) — shows "Interactivo" badge and opens in a new tab
- Authors: Lydia Hallie & Addy Osmani

## Test plan

- [ ] Visit `/cursos` and confirm a "Patterns.dev" card appears with the "Interactivo" badge
- [ ] Click "Ver curso" and confirm it opens https://www.patterns.dev/ in a new tab
- [ ] Visit `/cursos/patterns-dev` and confirm the detail page shows the "Ir al curso" external button