### PR TITLE
fix(lectura): guard against null parsed.content before sanitizeHtml

### DIFF
--- a/src/app/api/lectura/reader/route.ts
+++ b/src/app/api/lectura/reader/route.ts
@@ -44,7 +44,7 @@ export async function GET(request: Request) {
     const reader = new Readability(dom.window.document);
     const parsed = reader.parse();
 
-    if (!parsed) {
+    if (!parsed || !parsed.content) {
       return NextResponse.json({ error: 'Could not extract article content' }, { status: 502 });
     }
 


### PR DESCRIPTION
## Summary
- Widens the `!parsed` null guard to `!parsed || !parsed.content` so TypeScript narrows `parsed.content` to `string` before passing it to `sanitizeHtml`
- Fixes the build error: *Argument of type 'string | null | undefined' is not assignable to parameter of type 'string'*
- No behavior change for valid articles

## Test plan
- [ ] `pnpm build` completes without TypeScript errors
- [ ] Reader API still returns article content for allowed URLs