### PR TITLE
feat(sidebar): promote recursos to top-level section with Más recursos dropdown

### DIFF
--- a/src/components/ui/app-sidebar.tsx
+++ b/src/components/ui/app-sidebar.tsx
@@ -3,13 +3,16 @@
 import {
   AlertTriangle,
   Bell,
+  BookOpen,
   CalendarDays,
   Code2,
   Eye,
+  GraduationCap,
   Home,
   Image,
   Instagram,
   LayoutDashboard,
+  Layers,
   Library,
   LifeBuoy,
   Linkedin,
@@ -103,15 +106,21 @@ const getActividadesItems = (upcomingEvents: UpcomingEvent[] = []) => {
   ];
 };
 
-const getRecursosSubItems = () => [
-  { title: 'Lectura', url: '/lectura' },
-  { title: 'Cursos', url: '/cursos' },
-  { title: 'Software útil', url: '/software-util' },
-  { title: 'Especialidades', url: '/especialidades' },
-  { title: 'Influencers', url: '/influencers' },
-  { title: 'Música', url: '/music' },
-  { title: 'Series y películas', url: '/series-y-peliculas' },
-  { title: 'Preguntas frecuentes', url: '/preguntas-frecuentes' },
+const getRecursosItems = () => [
+  { title: 'Cursos', url: '/cursos', icon: GraduationCap },
+  { title: 'Lectura', url: '/lectura', icon: BookOpen },
+  { title: 'Especialidades', url: '/especialidades', icon: Layers },
+  {
+    title: 'Más recursos',
+    icon: Library,
+    items: [
+      { title: 'Software útil', url: '/software-util' },
+      { title: 'Influencers', url: '/influencers' },
+      { title: 'Música', url: '/music' },
+      { title: 'Series y películas', url: '/series-y-peliculas' },
+      { title: 'Preguntas frecuentes', url: '/preguntas-frecuentes' },
+    ],
+  },
 ];
 
 const socialNetworks = [
@@ -149,11 +158,6 @@ const socialNetworks = [
 
 const getComunidadItems = () => {
   return [
-    {
-      title: 'Recursos',
-      icon: Library,
-      items: getRecursosSubItems(),
-    },
     {
       title: 'Historia',
       url: '/historia',
@@ -250,6 +254,7 @@ export function AppSidebar(props: AppSidebarProps) {
       <SidebarContent>
         <NavMain items={getHomeItem()} />
         <NavMain items={getActividadesItems(upcomingEvents)} label="Actividades" />
+        <NavMain items={getRecursosItems()} label="Recursos" />
         <NavMain items={getComunidadItems()} label="Comunidad" />
         {user?.role === 'ADMIN' && (
           <NavMain items={getAdminItems(unreadNotificationsCount)} label="Administración" />


### PR DESCRIPTION
## Summary

- Adds a new **Recursos** sidebar section placed between Actividades and Comunidad
- Surfaces **Cursos**, **Lectura**, and **Especialidades** as direct, always-visible nav rows (with icons `GraduationCap`, `BookOpen`, `Layers`)
- Remaining links (Software útil, Influencers, Música, Series y películas, Preguntas frecuentes) are tucked behind a collapsible **"Más recursos"** toggle
- Removes the old **Recursos** collapsible item from the Comunidad group

## Test plan

- [ ] New **Recursos** section header appears below Actividades in the sidebar
- [ ] Cursos, Lectura, Especialidades are direct clickable rows navigating to `/cursos`, `/lectura`, `/especialidades`
- [ ] **Más recursos** is collapsed by default and expands to show the 5 remaining links
- [ ] Recursos no longer appears inside the Comunidad group
- [ ] Navigating to a hidden route (e.g. `/influencers`) auto-expands Más recursos and highlights the active sub-item