### PR TITLE
test(actions): add Jest unit tests for all server actions

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -29,10 +29,12 @@ jest.mock('next/navigation', () => ({
   }),
 }));
 
-// cookies() is async in Next.js 15+; individual tests call mockCookies() from
-// src/test/cookies.ts to configure its resolved value per scenario.
+// cookies() and headers() are async in Next.js 15+; individual tests call
+// mockCookies() / mockHeaders() from src/test/cookies.ts|headers.ts to
+// configure their resolved values per scenario.
 jest.mock('next/headers', () => ({
   cookies: jest.fn(),
+  headers: jest.fn(),
 }));
 
 // ─── Reset mocks between tests ───────────────────────────────────────────────

--- a/src/actions/advises/create-advise.test.ts
+++ b/src/actions/advises/create-advise.test.ts
@@ -1,0 +1,94 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import { createAdvise } from './create-advise';
+
+const baseUser = {
+  id: 'user-1',
+  name: 'Test User',
+  email: 'test@example.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'REGULAR' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const baseSession = {
+  id: 'session-1',
+  userId: 'user-1',
+  expires: new Date('2027-01-01'),
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const validContent = 'Este es un consejo útil con más de 10 caracteres.';
+
+describe('createAdvise', () => {
+  it('throws when content fails schema validation', async () => {
+    mockCookies({ sessionId: 'session-1' });
+
+    await expect(createAdvise('corto')).rejects.toThrow();
+
+    expect(prismaMock.advise.create).not.toHaveBeenCalled();
+  });
+
+  it('throws when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(createAdvise(validContent)).rejects.toThrow('User not authenticated');
+
+    expect(prismaMock.advise.create).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'ghost-session' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(createAdvise(validContent)).rejects.toThrow('Session not found');
+
+    expect(prismaMock.advise.create).not.toHaveBeenCalled();
+  });
+
+  it('throws when the user is not found in the database', async () => {
+    mockCookies({ sessionId: 'session-1' });
+    prismaMock.session.findUnique.mockResolvedValue(baseSession as any);
+    prismaMock.user.findUnique.mockResolvedValue(null);
+
+    await expect(createAdvise(validContent)).rejects.toThrow('User not found');
+
+    expect(prismaMock.advise.create).not.toHaveBeenCalled();
+  });
+
+  it('creates the advise and revalidates paths on success', async () => {
+    mockCookies({ sessionId: 'session-1' });
+    prismaMock.session.findUnique.mockResolvedValue(baseSession as any);
+    prismaMock.user.findUnique.mockResolvedValue(baseUser as any);
+    prismaMock.advise.create.mockResolvedValue({ id: 'advise-1' } as any);
+
+    await createAdvise(validContent);
+
+    expect(prismaMock.advise.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          content: validContent,
+          author: { connect: { id: 'user-1' } },
+        }),
+      }),
+    );
+    expect(revalidatePath).toHaveBeenCalledWith('/consejos');
+    expect(revalidatePath).toHaveBeenCalledWith('/');
+  });
+});

--- a/src/actions/advises/delete-advise.test.ts
+++ b/src/actions/advises/delete-advise.test.ts
@@ -1,0 +1,116 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import { deleteAdvise } from './delete-advise';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+const mockAdvise = { id: 'advise-1', authorId: 'user-regular', content: 'Un consejo cualquiera' };
+
+describe('deleteAdvise', () => {
+  it('throws when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(deleteAdvise('advise-1')).rejects.toThrow('User not authenticated');
+
+    expect(prismaMock.advise.delete).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'ghost-session' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(deleteAdvise('advise-1')).rejects.toThrow('Session not found');
+
+    expect(prismaMock.advise.delete).not.toHaveBeenCalled();
+  });
+
+  it('throws when the advise is not found', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+    prismaMock.advise.findUnique.mockResolvedValue(null);
+
+    await expect(deleteAdvise('advise-1')).rejects.toThrow('Consejo no encontrado');
+
+    expect(prismaMock.advise.delete).not.toHaveBeenCalled();
+  });
+
+  it('throws when the user is not the author and not an admin', async () => {
+    const otherUserSession = {
+      ...regularSession,
+      userId: 'user-other',
+      user: { ...regularUser, id: 'user-other' },
+    };
+    mockCookies({ sessionId: 'session-other' });
+    prismaMock.session.findUnique.mockResolvedValue(otherUserSession as any);
+    prismaMock.advise.findUnique.mockResolvedValue(mockAdvise as any);
+
+    await expect(deleteAdvise('advise-1')).rejects.toThrow(
+      'No tienes permisos para eliminar este consejo',
+    );
+
+    expect(prismaMock.advise.delete).not.toHaveBeenCalled();
+  });
+
+  it('allows the author to delete their own advise and revalidates paths', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+    prismaMock.advise.findUnique.mockResolvedValue(mockAdvise as any);
+    prismaMock.advise.delete.mockResolvedValue(mockAdvise as any);
+
+    await deleteAdvise('advise-1');
+
+    expect(prismaMock.advise.delete).toHaveBeenCalledWith({ where: { id: 'advise-1' } });
+    expect(revalidatePath).toHaveBeenCalledWith('/consejos');
+    expect(revalidatePath).toHaveBeenCalledWith('/');
+  });
+
+  it('allows an admin to delete any advise', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.advise.findUnique.mockResolvedValue(mockAdvise as any);
+    prismaMock.advise.delete.mockResolvedValue(mockAdvise as any);
+
+    await deleteAdvise('advise-1');
+
+    expect(prismaMock.advise.delete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/actions/advises/edit-advise.test.ts
+++ b/src/actions/advises/edit-advise.test.ts
@@ -1,0 +1,126 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import { editAdvise } from './edit-advise';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+const mockAdvise = { id: 'advise-1', authorId: 'user-regular', content: 'Contenido original' };
+const validContent = 'Contenido actualizado con más de 10 caracteres.';
+
+describe('editAdvise', () => {
+  it('throws when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(editAdvise({ id: 'advise-1', content: validContent })).rejects.toThrow(
+      'User not authenticated',
+    );
+
+    expect(prismaMock.advise.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'ghost-session' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(editAdvise({ id: 'advise-1', content: validContent })).rejects.toThrow(
+      'Session not found',
+    );
+
+    expect(prismaMock.advise.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the advise is not found', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+    prismaMock.advise.findUnique.mockResolvedValue(null);
+
+    await expect(editAdvise({ id: 'advise-1', content: validContent })).rejects.toThrow(
+      'Consejo no encontrado',
+    );
+
+    expect(prismaMock.advise.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the user is not the author and not an admin', async () => {
+    const otherUserSession = {
+      ...regularSession,
+      userId: 'user-other',
+      user: { ...regularUser, id: 'user-other' },
+    };
+    mockCookies({ sessionId: 'session-other' });
+    prismaMock.session.findUnique.mockResolvedValue(otherUserSession as any);
+    prismaMock.advise.findUnique.mockResolvedValue(mockAdvise as any);
+
+    await expect(editAdvise({ id: 'advise-1', content: validContent })).rejects.toThrow(
+      'No tienes permisos para editar este consejo',
+    );
+
+    expect(prismaMock.advise.update).not.toHaveBeenCalled();
+  });
+
+  it('allows the author to edit their own advise', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+    prismaMock.advise.findUnique.mockResolvedValue(mockAdvise as any);
+    prismaMock.advise.update.mockResolvedValue({ ...mockAdvise, content: validContent } as any);
+
+    await editAdvise({ id: 'advise-1', content: validContent });
+
+    expect(prismaMock.advise.update).toHaveBeenCalledWith({
+      where: { id: 'advise-1' },
+      data: { content: validContent },
+    });
+    expect(revalidatePath).toHaveBeenCalledWith('/consejos');
+  });
+
+  it('allows an admin to edit any advise', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.advise.findUnique.mockResolvedValue(mockAdvise as any);
+    prismaMock.advise.update.mockResolvedValue({ ...mockAdvise, content: validContent } as any);
+
+    await editAdvise({ id: 'advise-1', content: validContent });
+
+    expect(prismaMock.advise.update).toHaveBeenCalledTimes(1);
+    expect(revalidatePath).toHaveBeenCalledWith('/consejos');
+  });
+});

--- a/src/actions/advises/get-best-advises.test.ts
+++ b/src/actions/advises/get-best-advises.test.ts
@@ -1,0 +1,53 @@
+import { prismaMock } from '@/test/prisma';
+import { getBestAdvises } from './get-best-advises';
+
+const mockAdvises = [
+  {
+    id: 'advise-1',
+    content: 'El mejor consejo de todos.',
+    authorId: 'user-1',
+    createdAt: new Date('2025-01-01'),
+    updatedAt: new Date('2025-01-01'),
+    likes: [{ id: 'like-1', userId: 'user-2', adviseId: 'advise-1', createdAt: new Date() }],
+    author: { id: 'user-1', name: 'Alice', email: 'alice@example.com', image: null },
+  },
+  {
+    id: 'advise-2',
+    content: 'Otro gran consejo para la comunidad.',
+    authorId: 'user-2',
+    createdAt: new Date('2025-01-02'),
+    updatedAt: new Date('2025-01-02'),
+    likes: [],
+    author: { id: 'user-2', name: 'Bob', email: 'bob@example.com', image: null },
+  },
+];
+
+describe('getBestAdvises', () => {
+  it('returns the top 3 advises ordered by likes count', async () => {
+    prismaMock.advise.findMany.mockResolvedValue(mockAdvises as any);
+
+    const result = await getBestAdvises();
+
+    expect(result).toEqual(mockAdvises);
+    expect(prismaMock.advise.findMany).toHaveBeenCalledWith({
+      include: {
+        likes: true,
+        author: {
+          select: { id: true, name: true, email: true, image: true },
+        },
+      },
+      orderBy: {
+        likes: { _count: 'desc' },
+      },
+      take: 3,
+    });
+  });
+
+  it('returns an empty array when there are no advises', async () => {
+    prismaMock.advise.findMany.mockResolvedValue([]);
+
+    const result = await getBestAdvises();
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/actions/advises/like-advise.test.ts
+++ b/src/actions/advises/like-advise.test.ts
@@ -1,0 +1,71 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import { toggleLike } from './like-advise';
+
+const baseSession = {
+  id: 'session-1',
+  userId: 'user-1',
+  expires: new Date('2027-01-01'),
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const existingLike = {
+  id: 'like-1',
+  userId: 'user-1',
+  adviseId: 'advise-1',
+  createdAt: new Date('2025-01-01'),
+};
+
+describe('toggleLike', () => {
+  it('throws when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(toggleLike('advise-1')).rejects.toThrow('User not authenticated');
+
+    expect(prismaMock.like.create).not.toHaveBeenCalled();
+    expect(prismaMock.like.delete).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'ghost-session' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(toggleLike('advise-1')).rejects.toThrow('Session not found');
+
+    expect(prismaMock.like.create).not.toHaveBeenCalled();
+    expect(prismaMock.like.delete).not.toHaveBeenCalled();
+  });
+
+  it('creates a like when none exists and returns success', async () => {
+    mockCookies({ sessionId: 'session-1' });
+    prismaMock.session.findUnique.mockResolvedValue(baseSession as any);
+    prismaMock.like.findUnique.mockResolvedValue(null);
+    prismaMock.like.create.mockResolvedValue(existingLike as any);
+
+    const result = await toggleLike('advise-1');
+
+    expect(result).toEqual({ success: true });
+    expect(prismaMock.like.create).toHaveBeenCalledWith({
+      data: { userId: 'user-1', adviseId: 'advise-1' },
+    });
+    expect(prismaMock.like.delete).not.toHaveBeenCalled();
+    expect(revalidatePath).toHaveBeenCalledWith('/consejos');
+    expect(revalidatePath).toHaveBeenCalledWith('/consejos/advise-1');
+    expect(revalidatePath).toHaveBeenCalledWith('/');
+  });
+
+  it('deletes the like when one already exists and returns success', async () => {
+    mockCookies({ sessionId: 'session-1' });
+    prismaMock.session.findUnique.mockResolvedValue(baseSession as any);
+    prismaMock.like.findUnique.mockResolvedValue(existingLike as any);
+    prismaMock.like.delete.mockResolvedValue(existingLike as any);
+
+    const result = await toggleLike('advise-1');
+
+    expect(result).toEqual({ success: true });
+    expect(prismaMock.like.delete).toHaveBeenCalledWith({ where: { id: 'like-1' } });
+    expect(prismaMock.like.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/actions/analytics/fetch-page-visits.test.ts
+++ b/src/actions/analytics/fetch-page-visits.test.ts
@@ -1,0 +1,172 @@
+import { prismaMock } from '@/test/prisma';
+import { fetchPageVisits, getPageVisitStats } from './fetch-page-visits';
+
+const sampleVisit = {
+  id: 'visit-1',
+  path: '/home',
+  userId: null,
+  userAgent: 'Jest/1.0',
+  referer: null,
+  ipAddress: null,
+  createdAt: new Date('2025-06-01'),
+  user: null,
+};
+
+describe('fetchPageVisits', () => {
+  it('uses default limit of 100', async () => {
+    prismaMock.pageVisit.findMany.mockResolvedValue([sampleVisit] as any);
+
+    await fetchPageVisits();
+
+    expect(prismaMock.pageVisit.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 100 }),
+    );
+  });
+
+  it('respects a custom limit', async () => {
+    prismaMock.pageVisit.findMany.mockResolvedValue([] as any);
+
+    await fetchPageVisits(25);
+
+    expect(prismaMock.pageVisit.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 25 }),
+    );
+  });
+
+  it('orders results by createdAt descending', async () => {
+    prismaMock.pageVisit.findMany.mockResolvedValue([] as any);
+
+    await fetchPageVisits();
+
+    expect(prismaMock.pageVisit.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { createdAt: 'desc' } }),
+    );
+  });
+
+  it('includes user relation in the query', async () => {
+    prismaMock.pageVisit.findMany.mockResolvedValue([] as any);
+
+    await fetchPageVisits();
+
+    expect(prismaMock.pageVisit.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: { user: { select: { id: true, name: true, email: true } } },
+      }),
+    );
+  });
+
+  it('returns the array of page visits', async () => {
+    prismaMock.pageVisit.findMany.mockResolvedValue([sampleVisit] as any);
+
+    const result = await fetchPageVisits();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: 'visit-1', path: '/home' });
+  });
+});
+
+describe('getPageVisitStats', () => {
+  it('returns correct stats aggregating all prisma queries', async () => {
+    prismaMock.pageVisit.count
+      .mockResolvedValueOnce(500) // totalVisits
+      .mockResolvedValueOnce(20) // visitsToday
+      .mockResolvedValueOnce(80) // visitsThisWeek
+      .mockResolvedValueOnce(300); // visitsThisMonth
+
+    prismaMock.pageVisit.groupBy
+      .mockResolvedValueOnce([
+        { path: '/home', _count: { path: 200 } },
+        { path: '/about', _count: { path: 100 } },
+        { path: '/events', _count: { path: 50 } },
+      ] as any) // uniquePaths
+      .mockResolvedValueOnce([
+        { path: '/home', _count: { path: 200 } },
+        { path: '/about', _count: { path: 100 } },
+      ] as any) // topPages
+      .mockResolvedValueOnce([
+        { userId: 'user-1', _count: { userId: 5 } },
+        { userId: 'user-2', _count: { userId: 3 } },
+      ] as any); // visitsByUser
+
+    const result = await getPageVisitStats();
+
+    expect(result).toEqual({
+      totalVisits: 500,
+      visitsToday: 20,
+      visitsThisWeek: 80,
+      visitsThisMonth: 300,
+      uniquePaths: 3,
+      topPages: [
+        { path: '/home', count: 200 },
+        { path: '/about', count: 100 },
+      ],
+      uniqueUsers: 2,
+    });
+  });
+
+  it('returns uniquePaths as the length of the paths groupBy result', async () => {
+    prismaMock.pageVisit.count
+      .mockResolvedValueOnce(10)
+      .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(5)
+      .mockResolvedValueOnce(8);
+
+    prismaMock.pageVisit.groupBy
+      .mockResolvedValueOnce([
+        { path: '/a', _count: { path: 1 } },
+        { path: '/b', _count: { path: 2 } },
+        { path: '/c', _count: { path: 3 } },
+        { path: '/d', _count: { path: 4 } },
+      ] as any) // uniquePaths (4 distinct paths)
+      .mockResolvedValueOnce([] as any) // topPages
+      .mockResolvedValueOnce([] as any); // visitsByUser
+
+    const result = await getPageVisitStats();
+
+    expect(result.uniquePaths).toBe(4);
+    expect(result.uniqueUsers).toBe(0);
+    expect(result.topPages).toEqual([]);
+  });
+
+  it('queries topPages with a limit of 10 ordered by count desc', async () => {
+    prismaMock.pageVisit.count
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0);
+    prismaMock.pageVisit.groupBy
+      .mockResolvedValueOnce([] as any)
+      .mockResolvedValueOnce([] as any)
+      .mockResolvedValueOnce([] as any);
+
+    await getPageVisitStats();
+
+    expect(prismaMock.pageVisit.groupBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 10,
+        orderBy: { _count: { path: 'desc' } },
+      }),
+    );
+  });
+
+  it('excludes null userIds when counting unique users', async () => {
+    prismaMock.pageVisit.count
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(0);
+    prismaMock.pageVisit.groupBy
+      .mockResolvedValueOnce([] as any)
+      .mockResolvedValueOnce([] as any)
+      .mockResolvedValueOnce([] as any);
+
+    await getPageVisitStats();
+
+    expect(prismaMock.pageVisit.groupBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        by: ['userId'],
+        where: { userId: { not: null } },
+      }),
+    );
+  });
+});

--- a/src/actions/analytics/track-page-visit.test.ts
+++ b/src/actions/analytics/track-page-visit.test.ts
@@ -1,0 +1,149 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { mockHeaders } from '@/test/headers';
+import { trackPageVisit } from './track-page-visit';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+describe('trackPageVisit', () => {
+  it('records an anonymous visit when there is no session cookie', async () => {
+    mockCookies();
+    mockHeaders({
+      'user-agent': 'Jest/1.0',
+      'x-forwarded-for': '1.2.3.4',
+      referer: 'https://google.com',
+    });
+    prismaMock.pageVisit.create.mockResolvedValue({} as any);
+
+    await trackPageVisit('/home');
+
+    expect(prismaMock.pageVisit.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          path: '/home',
+          userId: null,
+          userAgent: 'Jest/1.0',
+          ipAddress: '1.2.3.4',
+          referer: 'https://google.com',
+        }),
+      }),
+    );
+  });
+
+  it('does not record a visit for admin users', async () => {
+    mockCookies({ sessionId: adminSession.id });
+    mockHeaders({});
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+
+    await trackPageVisit('/admin');
+
+    expect(prismaMock.pageVisit.create).not.toHaveBeenCalled();
+  });
+
+  it('records a visit with userId for a regular user session', async () => {
+    mockCookies({ sessionId: regularSession.id });
+    mockHeaders({ 'user-agent': 'Chrome/100', 'x-forwarded-for': '10.0.0.2' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+    prismaMock.pageVisit.create.mockResolvedValue({} as any);
+
+    await trackPageVisit('/events');
+
+    expect(prismaMock.pageVisit.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          path: '/events',
+          userId: 'user-regular',
+          userAgent: 'Chrome/100',
+          ipAddress: '10.0.0.2',
+        }),
+      }),
+    );
+  });
+
+  it('falls back to x-real-ip when x-forwarded-for is absent', async () => {
+    mockCookies();
+    mockHeaders({ 'x-real-ip': '192.168.0.50' });
+    prismaMock.pageVisit.create.mockResolvedValue({} as any);
+
+    await trackPageVisit('/about');
+
+    expect(prismaMock.pageVisit.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ ipAddress: '192.168.0.50' }),
+      }),
+    );
+  });
+
+  it('stores null for referer when the header is absent', async () => {
+    mockCookies();
+    mockHeaders({ 'user-agent': 'Jest/1.0' });
+    prismaMock.pageVisit.create.mockResolvedValue({} as any);
+
+    await trackPageVisit('/contact');
+
+    expect(prismaMock.pageVisit.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ referer: null }),
+      }),
+    );
+  });
+
+  it('records a visit even when the session cookie exists but session is not found in DB', async () => {
+    mockCookies({ sessionId: 'stale-session' });
+    mockHeaders({});
+    prismaMock.session.findUnique.mockResolvedValue(null);
+    prismaMock.pageVisit.create.mockResolvedValue({} as any);
+
+    await trackPageVisit('/page');
+
+    expect(prismaMock.pageVisit.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ userId: null }),
+      }),
+    );
+  });
+
+  it('silences errors and does not throw', async () => {
+    mockCookies();
+    mockHeaders({});
+    prismaMock.pageVisit.create.mockRejectedValue(new Error('DB error'));
+
+    await expect(trackPageVisit('/crash')).resolves.toBeUndefined();
+  });
+});

--- a/src/actions/announcements/create-announcement.test.ts
+++ b/src/actions/announcements/create-announcement.test.ts
@@ -1,0 +1,131 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import { createAnnouncement } from './create-announcement';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+const validData = {
+  title: 'Test Announcement Title',
+  content: 'This is valid announcement content for testing.',
+  category: 'general',
+  pinned: false,
+  published: true,
+  eventId: null,
+};
+
+const createdAnnouncement = {
+  id: 'ann-1',
+  ...validData,
+  authorId: 'user-admin',
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+describe('createAnnouncement', () => {
+  it('throws when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(createAnnouncement(validData)).rejects.toThrow('No autorizado');
+    expect(prismaMock.announcement.create).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(createAnnouncement(validData)).rejects.toThrow(
+      'No tienes permisos para crear anuncios',
+    );
+    expect(prismaMock.announcement.create).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session belongs to a non-admin user', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+
+    await expect(createAnnouncement(validData)).rejects.toThrow(
+      'No tienes permisos para crear anuncios',
+    );
+    expect(prismaMock.announcement.create).not.toHaveBeenCalled();
+  });
+
+  it('creates the announcement and revalidates /anuncios on success', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.announcement.create.mockResolvedValue(createdAnnouncement as any);
+
+    const result = await createAnnouncement(validData);
+
+    expect(prismaMock.announcement.create).toHaveBeenCalledWith({
+      data: {
+        title: validData.title,
+        content: validData.content,
+        category: validData.category,
+        pinned: validData.pinned,
+        published: validData.published,
+        authorId: 'user-admin',
+        eventId: null,
+      },
+    });
+    expect(result).toEqual(createdAnnouncement);
+    expect(revalidatePath).toHaveBeenCalledWith('/anuncios');
+  });
+
+  it('sets eventId and revalidates the event path when category is "evento"', async () => {
+    const eventData = { ...validData, category: 'evento', eventId: 'event-1' };
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.announcement.create.mockResolvedValue({
+      ...createdAnnouncement,
+      category: 'evento',
+      eventId: 'event-1',
+    } as any);
+
+    await createAnnouncement(eventData);
+
+    expect(prismaMock.announcement.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ category: 'evento', eventId: 'event-1' }),
+    });
+    expect(revalidatePath).toHaveBeenCalledWith('/anuncios');
+    expect(revalidatePath).toHaveBeenCalledWith('/eventos/event-1');
+  });
+});

--- a/src/actions/announcements/delete-announcement.test.ts
+++ b/src/actions/announcements/delete-announcement.test.ts
@@ -1,0 +1,85 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import { deleteAnnouncement } from './delete-announcement';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+describe('deleteAnnouncement', () => {
+  it('throws when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(deleteAnnouncement('ann-1')).rejects.toThrow('No autorizado');
+    expect(prismaMock.announcement.delete).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(deleteAnnouncement('ann-1')).rejects.toThrow(
+      'No tienes permisos para eliminar anuncios',
+    );
+    expect(prismaMock.announcement.delete).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session belongs to a non-admin user', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+
+    await expect(deleteAnnouncement('ann-1')).rejects.toThrow(
+      'No tienes permisos para eliminar anuncios',
+    );
+    expect(prismaMock.announcement.delete).not.toHaveBeenCalled();
+  });
+
+  it('deletes the announcement, revalidates /anuncios, and returns success', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.announcement.delete.mockResolvedValue({} as any);
+
+    const result = await deleteAnnouncement('ann-1');
+
+    expect(prismaMock.announcement.delete).toHaveBeenCalledWith({ where: { id: 'ann-1' } });
+    expect(revalidatePath).toHaveBeenCalledWith('/anuncios');
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/src/actions/announcements/get-announcements.test.ts
+++ b/src/actions/announcements/get-announcements.test.ts
@@ -1,0 +1,79 @@
+import { prismaMock } from '@/test/prisma';
+import { fetchAnnouncements, fetchAllAnnouncements } from './get-announcements';
+
+const publishedAnnouncement = {
+  id: 'ann-1',
+  title: 'Published Announcement',
+  content: 'Content here.',
+  category: 'general',
+  pinned: false,
+  published: true,
+  authorId: 'user-admin',
+  eventId: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+  author: { id: 'user-admin', name: 'Admin', image: null },
+};
+
+const unpublishedAnnouncement = {
+  ...publishedAnnouncement,
+  id: 'ann-2',
+  title: 'Unpublished Announcement',
+  published: false,
+};
+
+describe('fetchAnnouncements', () => {
+  it('returns published announcements ordered by pinned then date', async () => {
+    prismaMock.announcement.findMany.mockResolvedValue([publishedAnnouncement] as any);
+
+    const result = await fetchAnnouncements();
+
+    expect(result).toEqual([publishedAnnouncement]);
+    expect(prismaMock.announcement.findMany).toHaveBeenCalledWith({
+      where: { published: true },
+      orderBy: [{ pinned: 'desc' }, { createdAt: 'desc' }],
+      include: {
+        author: {
+          select: { id: true, name: true, image: true },
+        },
+      },
+    });
+  });
+
+  it('returns an empty array when there are no published announcements', async () => {
+    prismaMock.announcement.findMany.mockResolvedValue([]);
+
+    const result = await fetchAnnouncements();
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe('fetchAllAnnouncements', () => {
+  it('returns all announcements including unpublished', async () => {
+    prismaMock.announcement.findMany.mockResolvedValue([
+      publishedAnnouncement,
+      unpublishedAnnouncement,
+    ] as any);
+
+    const result = await fetchAllAnnouncements();
+
+    expect(result).toHaveLength(2);
+    expect(prismaMock.announcement.findMany).toHaveBeenCalledWith({
+      orderBy: [{ pinned: 'desc' }, { createdAt: 'desc' }],
+      include: {
+        author: {
+          select: { id: true, name: true, image: true },
+        },
+      },
+    });
+  });
+
+  it('returns an empty array when there are no announcements', async () => {
+    prismaMock.announcement.findMany.mockResolvedValue([]);
+
+    const result = await fetchAllAnnouncements();
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/actions/announcements/get-event-announcements.test.ts
+++ b/src/actions/announcements/get-event-announcements.test.ts
@@ -1,0 +1,43 @@
+import { prismaMock } from '@/test/prisma';
+import { getEventAnnouncements } from './get-event-announcements';
+
+const eventAnnouncement = {
+  id: 'ann-1',
+  title: 'Event Announcement',
+  content: 'Content about the event.',
+  category: 'evento',
+  pinned: false,
+  published: true,
+  authorId: 'user-admin',
+  eventId: 'event-1',
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+  author: { id: 'user-admin', name: 'Admin', image: null },
+};
+
+describe('getEventAnnouncements', () => {
+  it('returns published announcements for the given event', async () => {
+    prismaMock.announcement.findMany.mockResolvedValue([eventAnnouncement] as any);
+
+    const result = await getEventAnnouncements('event-1');
+
+    expect(result).toEqual([eventAnnouncement]);
+    expect(prismaMock.announcement.findMany).toHaveBeenCalledWith({
+      where: { eventId: 'event-1', published: true },
+      orderBy: [{ pinned: 'desc' }, { createdAt: 'desc' }],
+      include: {
+        author: {
+          select: { id: true, name: true, image: true },
+        },
+      },
+    });
+  });
+
+  it('returns an empty array when there are no announcements for the event', async () => {
+    prismaMock.announcement.findMany.mockResolvedValue([]);
+
+    const result = await getEventAnnouncements('event-empty');
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/actions/announcements/get-events-for-select.test.ts
+++ b/src/actions/announcements/get-events-for-select.test.ts
@@ -1,0 +1,31 @@
+import { prismaMock } from '@/test/prisma';
+import { getEventsForSelect } from './get-events-for-select';
+
+const eventOption = {
+  id: 'event-1',
+  name: 'PCN Conference 2025',
+  date: new Date('2025-06-01'),
+};
+
+describe('getEventsForSelect', () => {
+  it('returns non-deleted events ordered by date descending', async () => {
+    prismaMock.event.findMany.mockResolvedValue([eventOption] as any);
+
+    const result = await getEventsForSelect();
+
+    expect(result).toEqual([eventOption]);
+    expect(prismaMock.event.findMany).toHaveBeenCalledWith({
+      where: { deletedAt: null },
+      orderBy: { date: 'desc' },
+      select: { id: true, name: true, date: true },
+    });
+  });
+
+  it('returns an empty array when there are no active events', async () => {
+    prismaMock.event.findMany.mockResolvedValue([]);
+
+    const result = await getEventsForSelect();
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/actions/announcements/update-announcement.test.ts
+++ b/src/actions/announcements/update-announcement.test.ts
@@ -1,0 +1,132 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import { updateAnnouncement } from './update-announcement';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+const validData = {
+  title: 'Updated Announcement Title',
+  content: 'This is updated announcement content for testing.',
+  category: 'general',
+  pinned: false,
+  published: true,
+  eventId: null,
+};
+
+const updatedAnnouncement = {
+  id: 'ann-1',
+  ...validData,
+  authorId: 'user-admin',
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+describe('updateAnnouncement', () => {
+  it('throws when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(updateAnnouncement('ann-1', validData)).rejects.toThrow('No autorizado');
+    expect(prismaMock.announcement.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(updateAnnouncement('ann-1', validData)).rejects.toThrow(
+      'No tienes permisos para editar anuncios',
+    );
+    expect(prismaMock.announcement.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session belongs to a non-admin user', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+
+    await expect(updateAnnouncement('ann-1', validData)).rejects.toThrow(
+      'No tienes permisos para editar anuncios',
+    );
+    expect(prismaMock.announcement.update).not.toHaveBeenCalled();
+  });
+
+  it('updates the announcement and revalidates /anuncios on success', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.announcement.findUnique.mockResolvedValue({ eventId: null } as any);
+    prismaMock.announcement.update.mockResolvedValue(updatedAnnouncement as any);
+
+    const result = await updateAnnouncement('ann-1', validData);
+
+    expect(prismaMock.announcement.update).toHaveBeenCalledWith({
+      where: { id: 'ann-1' },
+      data: {
+        title: validData.title,
+        content: validData.content,
+        category: validData.category,
+        pinned: validData.pinned,
+        published: validData.published,
+        eventId: null,
+      },
+    });
+    expect(result).toEqual(updatedAnnouncement);
+    expect(revalidatePath).toHaveBeenCalledWith('/anuncios');
+  });
+
+  it('revalidates both the new and the old event path when eventId changes', async () => {
+    const dataWithEvent = { ...validData, category: 'evento', eventId: 'event-new' };
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    // previous announcement had a different eventId
+    prismaMock.announcement.findUnique.mockResolvedValue({ eventId: 'event-old' } as any);
+    prismaMock.announcement.update.mockResolvedValue({
+      ...updatedAnnouncement,
+      category: 'evento',
+      eventId: 'event-new',
+    } as any);
+
+    await updateAnnouncement('ann-1', dataWithEvent);
+
+    expect(revalidatePath).toHaveBeenCalledWith('/anuncios');
+    expect(revalidatePath).toHaveBeenCalledWith('/eventos/event-new');
+    expect(revalidatePath).toHaveBeenCalledWith('/eventos/event-old');
+  });
+});

--- a/src/actions/auth/complete-password-reset.test.ts
+++ b/src/actions/auth/complete-password-reset.test.ts
@@ -1,0 +1,77 @@
+import bcrypt from 'bcryptjs';
+import { prismaMock } from '@/test/prisma';
+import { completePasswordReset } from './complete-password-reset';
+
+jest.mock('bcryptjs');
+
+const bcryptMock = bcrypt as jest.Mocked<typeof bcrypt>;
+
+const baseUser = {
+  id: 'user-1',
+  name: 'Test User',
+  email: 'test@example.com',
+  password: 'old-hash',
+  emailVerified: true,
+  role: 'REGULAR' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const validToken = {
+  id: 'token-reset-1',
+  email: 'test@example.com',
+  code: '654321',
+  used: false,
+  expiresAt: new Date('2027-01-01'),
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+describe('completePasswordReset', () => {
+  it('throws when the token is not found', async () => {
+    prismaMock.passwordResetToken.findFirst.mockResolvedValue(null);
+
+    await expect(completePasswordReset('test@example.com', '000000', 'NewP@ss1')).rejects.toThrow(
+      'Código inválido o expirado. Solicitá un nuevo código.',
+    );
+
+    expect(prismaMock.user.findUnique).not.toHaveBeenCalled();
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('throws when the user is not found despite a valid token', async () => {
+    prismaMock.passwordResetToken.findFirst.mockResolvedValue(validToken as any);
+    prismaMock.user.findUnique.mockResolvedValue(null);
+
+    await expect(completePasswordReset('test@example.com', '654321', 'NewP@ss1')).rejects.toThrow(
+      'Usuario no encontrado',
+    );
+
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('hashes the password, runs the transaction, and returns success', async () => {
+    prismaMock.passwordResetToken.findFirst.mockResolvedValue(validToken as any);
+    prismaMock.user.findUnique.mockResolvedValue(baseUser as any);
+    bcryptMock.hash.mockResolvedValue('new-hash' as never);
+    prismaMock.$transaction.mockResolvedValue([undefined, undefined, undefined] as any);
+
+    const result = await completePasswordReset('test@example.com', '654321', 'NewP@ss1');
+
+    expect(result).toEqual({ success: true });
+    expect(bcryptMock.hash).toHaveBeenCalledWith('NewP@ss1', 10);
+    expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/actions/auth/request-password-reset.test.ts
+++ b/src/actions/auth/request-password-reset.test.ts
@@ -1,0 +1,93 @@
+import { prismaMock } from '@/test/prisma';
+import { requestPasswordReset } from './request-password-reset';
+
+jest.mock('@/lib/email', () => ({
+  sendEmail: jest.fn().mockResolvedValue(undefined),
+  generateVerificationCode: jest.fn().mockReturnValue('654321'),
+  getCodeExpirationDate: jest.fn().mockReturnValue(new Date('2027-01-01')),
+  checkRateLimit: jest.fn().mockReturnValue(0),
+  RATE_LIMIT_SECONDS: 60,
+}));
+jest.mock('@react-email/render', () => ({ render: jest.fn().mockResolvedValue('<html/>') }));
+jest.mock('@/components/auth/reset-password-email', () => ({
+  PasswordResetCodeEmail: jest.fn(),
+}));
+
+import * as emailLib from '@/lib/email';
+const emailLibMock = emailLib as jest.Mocked<typeof emailLib>;
+
+const baseUser = {
+  id: 'user-1',
+  name: 'Test User',
+  email: 'test@example.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'REGULAR' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+describe('requestPasswordReset', () => {
+  beforeEach(() => {
+    emailLibMock.checkRateLimit.mockReturnValue(0);
+  });
+
+  it('returns success without revealing whether the email exists when the user is not found', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+
+    const result = await requestPasswordReset('nobody@example.com');
+
+    expect(result).toEqual({ success: true, waitSeconds: 0 });
+    expect(prismaMock.passwordResetToken.create).not.toHaveBeenCalled();
+    expect(emailLibMock.sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('throws a RATE_LIMIT error when the user must wait', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(baseUser as any);
+    prismaMock.passwordResetToken.findFirst.mockResolvedValue({
+      id: 'token-old',
+      email: 'test@example.com',
+      code: '000000',
+      used: false,
+      expiresAt: new Date('2027-01-01'),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as any);
+    emailLibMock.checkRateLimit.mockReturnValue(45);
+
+    await expect(requestPasswordReset('test@example.com')).rejects.toThrow('RATE_LIMIT:45');
+
+    expect(prismaMock.passwordResetToken.create).not.toHaveBeenCalled();
+  });
+
+  it('invalidates old tokens, creates a new token, sends the email, and returns success', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(baseUser as any);
+    prismaMock.passwordResetToken.findFirst.mockResolvedValue(null);
+    prismaMock.passwordResetToken.updateMany.mockResolvedValue({ count: 0 } as any);
+    prismaMock.passwordResetToken.create.mockResolvedValue({} as any);
+
+    const result = await requestPasswordReset('test@example.com');
+
+    expect(result).toEqual({ success: true, waitSeconds: 60 });
+    expect(prismaMock.passwordResetToken.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ email: 'test@example.com', used: false }),
+        data: { used: true },
+      }),
+    );
+    expect(prismaMock.passwordResetToken.create).toHaveBeenCalledTimes(1);
+    expect(emailLibMock.sendEmail).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/actions/auth/send-verification-code.test.ts
+++ b/src/actions/auth/send-verification-code.test.ts
@@ -1,0 +1,104 @@
+import { prismaMock } from '@/test/prisma';
+import { sendVerificationCode } from './send-verification-code';
+
+jest.mock('@/lib/email', () => ({
+  sendEmail: jest.fn().mockResolvedValue(undefined),
+  generateVerificationCode: jest.fn().mockReturnValue('123456'),
+  getCodeExpirationDate: jest.fn().mockReturnValue(new Date('2027-01-01')),
+  checkRateLimit: jest.fn().mockReturnValue(0),
+  RATE_LIMIT_SECONDS: 60,
+}));
+jest.mock('@react-email/render', () => ({ render: jest.fn().mockResolvedValue('<html/>') }));
+jest.mock('@/components/auth/verification-email', () => ({
+  EmailVerificationEmail: jest.fn(),
+}));
+
+// Pull the mocked module so individual tests can override its return values.
+import * as emailLib from '@/lib/email';
+const emailLibMock = emailLib as jest.Mocked<typeof emailLib>;
+
+const baseUser = {
+  id: 'user-1',
+  name: 'Test User',
+  email: 'test@example.com',
+  password: 'hash',
+  emailVerified: false,
+  role: 'REGULAR' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+describe('sendVerificationCode', () => {
+  beforeEach(() => {
+    // Reset rate limit to "not rate-limited" before each test.
+    emailLibMock.checkRateLimit.mockReturnValue(0);
+  });
+
+  it('throws when the user is not found', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+
+    await expect(sendVerificationCode('unknown@example.com')).rejects.toThrow(
+      'Usuario no encontrado',
+    );
+
+    expect(prismaMock.emailVerificationToken.create).not.toHaveBeenCalled();
+  });
+
+  it('returns alreadyVerified when the user email is already verified', async () => {
+    prismaMock.user.findUnique.mockResolvedValue({ ...baseUser, emailVerified: true } as any);
+
+    const result = await sendVerificationCode('test@example.com');
+
+    expect(result).toEqual({ success: true, alreadyVerified: true, waitSeconds: 0 });
+    expect(prismaMock.emailVerificationToken.create).not.toHaveBeenCalled();
+  });
+
+  it('throws a RATE_LIMIT error when the user must wait', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(baseUser as any);
+    prismaMock.emailVerificationToken.findFirst.mockResolvedValue({
+      id: 'token-old',
+      email: 'test@example.com',
+      code: '000000',
+      used: false,
+      expiresAt: new Date('2027-01-01'),
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as any);
+    emailLibMock.checkRateLimit.mockReturnValue(30);
+
+    await expect(sendVerificationCode('test@example.com')).rejects.toThrow('RATE_LIMIT:30');
+
+    expect(prismaMock.emailVerificationToken.create).not.toHaveBeenCalled();
+  });
+
+  it('invalidates old tokens, creates a new token, sends the email, and returns success', async () => {
+    prismaMock.user.findUnique.mockResolvedValue(baseUser as any);
+    prismaMock.emailVerificationToken.findFirst.mockResolvedValue(null);
+    prismaMock.emailVerificationToken.updateMany.mockResolvedValue({ count: 0 } as any);
+    prismaMock.emailVerificationToken.create.mockResolvedValue({} as any);
+
+    const result = await sendVerificationCode('test@example.com');
+
+    expect(result).toEqual({ success: true, alreadyVerified: false, waitSeconds: 60 });
+    expect(prismaMock.emailVerificationToken.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ email: 'test@example.com', used: false }),
+        data: { used: true },
+      }),
+    );
+    expect(prismaMock.emailVerificationToken.create).toHaveBeenCalledTimes(1);
+    expect(emailLibMock.sendEmail).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/actions/auth/sign-out.test.ts
+++ b/src/actions/auth/sign-out.test.ts
@@ -1,0 +1,22 @@
+import { redirect } from 'next/navigation';
+import { mockCookies } from '@/test/cookies';
+import { signOut } from './sign-out';
+
+describe('signOut', () => {
+  it('deletes the sessionId cookie and redirects to the sign-in page', async () => {
+    const store = mockCookies({ sessionId: 'abc' });
+
+    await expect(signOut()).rejects.toThrow('NEXT_REDIRECT:/autenticacion/iniciar-sesion');
+
+    expect(store.delete).toHaveBeenCalledWith('sessionId');
+    expect(redirect).toHaveBeenCalledWith('/autenticacion/iniciar-sesion');
+  });
+
+  it('still redirects even when there is no sessionId cookie', async () => {
+    const store = mockCookies();
+
+    await expect(signOut()).rejects.toThrow('NEXT_REDIRECT:/autenticacion/iniciar-sesion');
+
+    expect(store.delete).toHaveBeenCalledWith('sessionId');
+  });
+});

--- a/src/actions/auth/verify-email-code.test.ts
+++ b/src/actions/auth/verify-email-code.test.ts
@@ -1,0 +1,84 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { verifyEmailCode } from './verify-email-code';
+
+const baseUser = {
+  id: 'user-1',
+  name: 'Test User',
+  email: 'test@example.com',
+  password: 'hash',
+  emailVerified: false,
+  role: 'REGULAR' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const validToken = {
+  id: 'token-1',
+  email: 'test@example.com',
+  code: '123456',
+  used: false,
+  expiresAt: new Date('2027-01-01'),
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+describe('verifyEmailCode', () => {
+  it('throws when the token is not found', async () => {
+    prismaMock.emailVerificationToken.findFirst.mockResolvedValue(null);
+
+    await expect(verifyEmailCode('test@example.com', '000000')).rejects.toThrow(
+      'Código inválido o expirado',
+    );
+
+    expect(prismaMock.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('throws when the user is not found despite a valid token', async () => {
+    prismaMock.emailVerificationToken.findFirst.mockResolvedValue(validToken as any);
+    prismaMock.user.findUnique.mockResolvedValue(null);
+
+    await expect(verifyEmailCode('test@example.com', '123456')).rejects.toThrow(
+      'Usuario no encontrado',
+    );
+
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('runs the transaction, creates a session, sets the cookie, and returns success', async () => {
+    const store = mockCookies();
+    prismaMock.emailVerificationToken.findFirst.mockResolvedValue(validToken as any);
+    prismaMock.user.findUnique.mockResolvedValue(baseUser as any);
+    prismaMock.$transaction.mockResolvedValue([undefined, undefined] as any);
+    prismaMock.session.create.mockResolvedValue({
+      id: 'session-new',
+      userId: 'user-1',
+      expires: new Date('2027-01-01'),
+      createdAt: new Date('2025-01-01'),
+      updatedAt: new Date('2025-01-01'),
+    } as any);
+
+    const result = await verifyEmailCode('test@example.com', '123456');
+
+    expect(result).toEqual({ success: true });
+    expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+    expect(prismaMock.session.create).toHaveBeenCalledTimes(1);
+    expect(store.set).toHaveBeenCalledWith(
+      'sessionId',
+      'session-new',
+      expect.objectContaining({ httpOnly: true }),
+    );
+  });
+});

--- a/src/actions/auth/verify-reset-code.test.ts
+++ b/src/actions/auth/verify-reset-code.test.ts
@@ -1,0 +1,30 @@
+import { prismaMock } from '@/test/prisma';
+import { verifyResetCode } from './verify-reset-code';
+
+const validToken = {
+  id: 'token-reset-1',
+  email: 'test@example.com',
+  code: '654321',
+  used: false,
+  expiresAt: new Date('2027-01-01'),
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+describe('verifyResetCode', () => {
+  it('throws when the token is not found', async () => {
+    prismaMock.passwordResetToken.findFirst.mockResolvedValue(null);
+
+    await expect(verifyResetCode('test@example.com', '000000')).rejects.toThrow(
+      'Código inválido o expirado',
+    );
+  });
+
+  it('returns success with the tokenId when a valid token is found', async () => {
+    prismaMock.passwordResetToken.findFirst.mockResolvedValue(validToken as any);
+
+    const result = await verifyResetCode('test@example.com', '654321');
+
+    expect(result).toEqual({ success: true, tokenId: 'token-reset-1' });
+  });
+});

--- a/src/actions/comments/create-comment.test.ts
+++ b/src/actions/comments/create-comment.test.ts
@@ -1,0 +1,119 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import { createComment } from './create-comment';
+
+const baseSession = {
+  id: 'session-1',
+  userId: 'user-1',
+  expires: new Date('2027-01-01'),
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const mockComment = {
+  id: 'comment-1',
+  content: 'Un comentario válido',
+  authorId: 'user-1',
+  adviseId: 'advise-1',
+  parentCommentId: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+  author: {
+    id: 'user-1',
+    name: 'Test User',
+    email: 'test@example.com',
+    image: null,
+  },
+};
+
+const validInput = {
+  content: 'Un comentario válido',
+  adviseId: 'advise-1',
+  parentCommentId: null,
+};
+
+describe('createComment', () => {
+  it('throws a ZodError when content is empty', async () => {
+    mockCookies({ sessionId: 'session-1' });
+
+    await expect(
+      createComment({ content: '', adviseId: 'advise-1', parentCommentId: null }),
+    ).rejects.toThrow('El comentario no puede estar vacío');
+
+    expect(prismaMock.comment.create).not.toHaveBeenCalled();
+  });
+
+  it('throws a ZodError when content exceeds 500 characters', async () => {
+    mockCookies({ sessionId: 'session-1' });
+    const longContent = 'a'.repeat(501);
+
+    await expect(
+      createComment({ content: longContent, adviseId: 'advise-1', parentCommentId: null }),
+    ).rejects.toThrow('El comentario no puede tener más de 500 caracteres');
+
+    expect(prismaMock.comment.create).not.toHaveBeenCalled();
+  });
+
+  it('throws when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(createComment(validInput)).rejects.toThrow('No autenticado');
+
+    expect(prismaMock.comment.create).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'ghost-session' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(createComment(validInput)).rejects.toThrow('Sesión no encontrada');
+
+    expect(prismaMock.comment.create).not.toHaveBeenCalled();
+  });
+
+  it('creates the comment, revalidates the path, and returns the comment', async () => {
+    mockCookies({ sessionId: 'session-1' });
+    prismaMock.session.findUnique.mockResolvedValue(baseSession as any);
+    prismaMock.comment.create.mockResolvedValue(mockComment as any);
+
+    const result = await createComment(validInput);
+
+    expect(result).toEqual(mockComment);
+    expect(prismaMock.comment.create).toHaveBeenCalledWith({
+      data: {
+        content: validInput.content,
+        authorId: 'user-1',
+        adviseId: 'advise-1',
+        parentCommentId: null,
+      },
+      include: {
+        author: {
+          select: { id: true, name: true, email: true, image: true },
+        },
+      },
+    });
+    expect(revalidatePath).toHaveBeenCalledWith('/consejos/advise-1');
+  });
+
+  it('creates a reply when parentCommentId is provided', async () => {
+    mockCookies({ sessionId: 'session-1' });
+    prismaMock.session.findUnique.mockResolvedValue(baseSession as any);
+    prismaMock.comment.create.mockResolvedValue({
+      ...mockComment,
+      parentCommentId: 'comment-parent',
+    } as any);
+
+    const result = await createComment({
+      ...validInput,
+      parentCommentId: 'comment-parent',
+    });
+
+    expect(result).toMatchObject({ parentCommentId: 'comment-parent' });
+    expect(prismaMock.comment.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ parentCommentId: 'comment-parent' }),
+      }),
+    );
+  });
+});

--- a/src/actions/errors/fetch-errors.test.ts
+++ b/src/actions/errors/fetch-errors.test.ts
@@ -1,0 +1,124 @@
+import { prismaMock } from '@/test/prisma';
+import { fetchErrors, getErrorStats } from './fetch-errors';
+
+const sampleError = {
+  id: 'error-1',
+  message: 'Something broke',
+  stack: null,
+  path: '/home',
+  userId: null,
+  userAgent: null,
+  ipAddress: null,
+  metadata: null,
+  resolved: false,
+  resolvedAt: null,
+  resolvedBy: null,
+  createdAt: new Date('2025-06-01'),
+  user: null,
+  resolver: null,
+};
+
+describe('fetchErrors', () => {
+  it('uses default page=1 and limit=50 (skip=0, take=50)', async () => {
+    prismaMock.errorLog.findMany.mockResolvedValue([sampleError] as any);
+    prismaMock.errorLog.count.mockResolvedValue(1);
+
+    const result = await fetchErrors();
+
+    expect(prismaMock.errorLog.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 0, take: 50 }),
+    );
+    expect(result.pagination).toEqual({ page: 1, limit: 50, total: 1, totalPages: 1 });
+  });
+
+  it('calculates skip correctly for custom page and limit', async () => {
+    prismaMock.errorLog.findMany.mockResolvedValue([] as any);
+    prismaMock.errorLog.count.mockResolvedValue(100);
+
+    const result = await fetchErrors(3, 10);
+
+    expect(prismaMock.errorLog.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 20, take: 10 }),
+    );
+    expect(result.pagination).toEqual({ page: 3, limit: 10, total: 100, totalPages: 10 });
+  });
+
+  it('orders results by createdAt descending', async () => {
+    prismaMock.errorLog.findMany.mockResolvedValue([] as any);
+    prismaMock.errorLog.count.mockResolvedValue(0);
+
+    await fetchErrors();
+
+    expect(prismaMock.errorLog.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { createdAt: 'desc' } }),
+    );
+  });
+
+  it('includes user and resolver relations', async () => {
+    prismaMock.errorLog.findMany.mockResolvedValue([] as any);
+    prismaMock.errorLog.count.mockResolvedValue(0);
+
+    await fetchErrors();
+
+    expect(prismaMock.errorLog.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: {
+          user: { select: { id: true, name: true, email: true } },
+          resolver: { select: { id: true, name: true, email: true } },
+        },
+      }),
+    );
+  });
+
+  it('returns errors alongside pagination metadata', async () => {
+    prismaMock.errorLog.findMany.mockResolvedValue([sampleError] as any);
+    prismaMock.errorLog.count.mockResolvedValue(1);
+
+    const result = await fetchErrors();
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatchObject({ id: 'error-1', message: 'Something broke' });
+  });
+
+  it('returns correct totalPages when total is not evenly divisible', async () => {
+    prismaMock.errorLog.findMany.mockResolvedValue([] as any);
+    prismaMock.errorLog.count.mockResolvedValue(55);
+
+    const result = await fetchErrors(1, 20);
+
+    expect(result.pagination.totalPages).toBe(3);
+  });
+});
+
+describe('getErrorStats', () => {
+  it('returns correct stats aggregating all prisma queries', async () => {
+    prismaMock.errorLog.count
+      .mockResolvedValueOnce(50) // totalErrors
+      .mockResolvedValueOnce(15) // unresolvedErrors
+      .mockResolvedValueOnce(3) // errorsToday
+      .mockResolvedValueOnce(12); // errorsThisWeek
+
+    const result = await getErrorStats();
+
+    expect(result).toEqual({
+      totalErrors: 50,
+      unresolvedErrors: 15,
+      errorsToday: 3,
+      errorsThisWeek: 12,
+    });
+  });
+
+  it('counts unresolved errors with resolved=false filter', async () => {
+    prismaMock.errorLog.count
+      .mockResolvedValueOnce(10)
+      .mockResolvedValueOnce(5)
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(7);
+
+    await getErrorStats();
+
+    expect(prismaMock.errorLog.count).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { resolved: false } }),
+    );
+  });
+});

--- a/src/actions/errors/log-error.test.ts
+++ b/src/actions/errors/log-error.test.ts
@@ -1,0 +1,238 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { mockHeaders } from '@/test/headers';
+import { logError, logClientError } from './log-error';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+describe('logError', () => {
+  it('creates an error log without userId for an anonymous request', async () => {
+    mockCookies();
+    mockHeaders({ 'user-agent': 'Jest/1.0', 'x-forwarded-for': '1.2.3.4' });
+    prismaMock.errorLog.create.mockResolvedValue({} as any);
+
+    const error = new Error('Something went wrong');
+    await logError(error, { path: '/api/test' });
+
+    expect(prismaMock.errorLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          message: 'Something went wrong',
+          stack: expect.stringContaining('Something went wrong'),
+          path: '/api/test',
+          userId: null,
+          userAgent: 'Jest/1.0',
+          ipAddress: '1.2.3.4',
+        }),
+      }),
+    );
+  });
+
+  it('does not log errors for admin users', async () => {
+    mockCookies({ sessionId: adminSession.id });
+    mockHeaders({});
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+
+    await logError(new Error('Admin error'));
+
+    expect(prismaMock.errorLog.create).not.toHaveBeenCalled();
+  });
+
+  it('creates an error log with userId for a regular user session', async () => {
+    mockCookies({ sessionId: regularSession.id });
+    mockHeaders({ 'user-agent': 'Chrome/100', 'x-forwarded-for': '10.0.0.1' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+    prismaMock.errorLog.create.mockResolvedValue({} as any);
+
+    await logError(new Error('User error'));
+
+    expect(prismaMock.errorLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: 'user-regular',
+          userAgent: 'Chrome/100',
+          ipAddress: '10.0.0.1',
+        }),
+      }),
+    );
+  });
+
+  it('handles non-Error objects by converting them to string', async () => {
+    mockCookies();
+    mockHeaders({});
+    prismaMock.errorLog.create.mockResolvedValue({} as any);
+
+    await logError('plain string error');
+
+    expect(prismaMock.errorLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          message: 'plain string error',
+          stack: undefined,
+        }),
+      }),
+    );
+  });
+
+  it('falls back to x-real-ip when x-forwarded-for is absent', async () => {
+    mockCookies();
+    mockHeaders({ 'x-real-ip': '172.16.0.1' });
+    prismaMock.errorLog.create.mockResolvedValue({} as any);
+
+    await logError(new Error('IP fallback'));
+
+    expect(prismaMock.errorLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ ipAddress: '172.16.0.1' }),
+      }),
+    );
+  });
+
+  it('serialises metadata to JSON when provided', async () => {
+    mockCookies();
+    mockHeaders({});
+    prismaMock.errorLog.create.mockResolvedValue({} as any);
+
+    await logError(new Error('Meta error'), { metadata: { component: 'Header' } });
+
+    expect(prismaMock.errorLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          metadata: JSON.stringify({ component: 'Header' }),
+        }),
+      }),
+    );
+  });
+
+  it('silences errors and does not throw', async () => {
+    mockCookies();
+    mockHeaders({});
+    prismaMock.errorLog.create.mockRejectedValue(new Error('DB error'));
+
+    await expect(logError(new Error('Original'))).resolves.toBeUndefined();
+  });
+});
+
+describe('logClientError', () => {
+  it('creates an error log without userId for an anonymous request', async () => {
+    mockCookies();
+    mockHeaders({ 'user-agent': 'Jest/1.0', 'x-forwarded-for': '5.6.7.8' });
+    prismaMock.errorLog.create.mockResolvedValue({} as any);
+
+    await logClientError({
+      message: 'Client error',
+      stack: 'Error: Client error\n  at Component',
+      path: '/page',
+    });
+
+    expect(prismaMock.errorLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          message: 'Client error',
+          stack: 'Error: Client error\n  at Component',
+          path: '/page',
+          userId: null,
+          userAgent: 'Jest/1.0',
+          ipAddress: '5.6.7.8',
+        }),
+      }),
+    );
+  });
+
+  it('does not log client errors for admin users', async () => {
+    mockCookies({ sessionId: adminSession.id });
+    mockHeaders({});
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+
+    await logClientError({ message: 'Admin client error' });
+
+    expect(prismaMock.errorLog.create).not.toHaveBeenCalled();
+  });
+
+  it('creates an error log with userId for a regular user session', async () => {
+    mockCookies({ sessionId: regularSession.id });
+    mockHeaders({ 'user-agent': 'Firefox/99' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+    prismaMock.errorLog.create.mockResolvedValue({} as any);
+
+    await logClientError({ message: 'Regular client error' });
+
+    expect(prismaMock.errorLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ userId: 'user-regular' }),
+      }),
+    );
+  });
+
+  it('stores null for stack when not provided', async () => {
+    mockCookies();
+    mockHeaders({});
+    prismaMock.errorLog.create.mockResolvedValue({} as any);
+
+    await logClientError({ message: 'No stack' });
+
+    expect(prismaMock.errorLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ stack: null }),
+      }),
+    );
+  });
+
+  it('serialises metadata to JSON when provided', async () => {
+    mockCookies();
+    mockHeaders({});
+    prismaMock.errorLog.create.mockResolvedValue({} as any);
+
+    await logClientError({ message: 'Meta', metadata: { browser: 'Chrome' } });
+
+    expect(prismaMock.errorLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ metadata: JSON.stringify({ browser: 'Chrome' }) }),
+      }),
+    );
+  });
+
+  it('silences errors and does not throw', async () => {
+    mockCookies();
+    mockHeaders({});
+    prismaMock.errorLog.create.mockRejectedValue(new Error('DB error'));
+
+    await expect(logClientError({ message: 'Fail' })).resolves.toBeUndefined();
+  });
+});

--- a/src/actions/errors/mark-as-resolved.test.ts
+++ b/src/actions/errors/mark-as-resolved.test.ts
@@ -1,0 +1,100 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import { markErrorAsResolved } from './mark-as-resolved';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+describe('markErrorAsResolved', () => {
+  it('throws when there is no session cookie', async () => {
+    mockCookies();
+
+    await expect(markErrorAsResolved('error-1')).rejects.toThrow('No autorizado');
+    expect(prismaMock.session.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'session-xxx' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(markErrorAsResolved('error-1')).rejects.toThrow(
+      'Solo los administradores pueden marcar errores como resueltos',
+    );
+    expect(prismaMock.errorLog.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session belongs to a non-admin user', async () => {
+    mockCookies({ sessionId: regularSession.id });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+
+    await expect(markErrorAsResolved('error-1')).rejects.toThrow(
+      'Solo los administradores pueden marcar errores como resueltos',
+    );
+    expect(prismaMock.errorLog.update).not.toHaveBeenCalled();
+  });
+
+  it('updates the error log as resolved when called by an admin', async () => {
+    mockCookies({ sessionId: adminSession.id });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.errorLog.update.mockResolvedValue({} as any);
+
+    await markErrorAsResolved('error-42');
+
+    expect(prismaMock.errorLog.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'error-42' },
+        data: expect.objectContaining({
+          resolved: true,
+          resolvedBy: 'user-admin',
+          resolvedAt: expect.any(Date),
+        }),
+      }),
+    );
+  });
+
+  it('calls revalidatePath("/errores") after a successful update', async () => {
+    mockCookies({ sessionId: adminSession.id });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.errorLog.update.mockResolvedValue({} as any);
+
+    await markErrorAsResolved('error-42');
+
+    expect(revalidatePath).toHaveBeenCalledWith('/errores');
+  });
+});

--- a/src/actions/events/cancel-registration.test.ts
+++ b/src/actions/events/cancel-registration.test.ts
@@ -1,0 +1,116 @@
+import { revalidatePath } from 'next/cache';
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { cancelRegistration } from './cancel-registration';
+
+jest.mock('@/actions/notifications/notify-admins', () => ({
+  notifyAdmins: jest.fn().mockResolvedValue(undefined),
+}));
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const mockEvent = {
+  id: 'event-1',
+  name: 'Tech Talk',
+  deletedAt: null,
+};
+
+const mockRegistration = {
+  id: 'reg-1',
+  eventId: 'event-1',
+  userId: 'user-admin',
+  cancelledAt: null,
+  createdAt: new Date('2025-06-01'),
+  user: adminUser,
+};
+
+describe('cancelRegistration', () => {
+  it('throws when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(cancelRegistration({ eventId: 'event-1' })).rejects.toThrow('No autorizado');
+
+    expect(prismaMock.session.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'ghost-session' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(cancelRegistration({ eventId: 'event-1' })).rejects.toThrow('No autorizado');
+
+    expect(prismaMock.event.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('throws when the event is not found', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.event.findFirst.mockResolvedValue(null);
+
+    await expect(cancelRegistration({ eventId: 'event-1' })).rejects.toThrow(
+      'Evento no encontrado',
+    );
+
+    expect(prismaMock.eventRegistration.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('throws when the registration is not found', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.event.findFirst.mockResolvedValue(mockEvent as any);
+    prismaMock.eventRegistration.findFirst.mockResolvedValue(null);
+
+    await expect(cancelRegistration({ eventId: 'event-1' })).rejects.toThrow(
+      'Inscripción no encontrada o ya cancelada',
+    );
+
+    expect(prismaMock.eventRegistration.update).not.toHaveBeenCalled();
+  });
+
+  it('marks the registration as cancelled, revalidates path, and returns success', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.event.findFirst.mockResolvedValue(mockEvent as any);
+    prismaMock.eventRegistration.findFirst.mockResolvedValue(mockRegistration as any);
+    prismaMock.eventRegistration.update.mockResolvedValue({
+      ...mockRegistration,
+      cancelledAt: new Date(),
+    } as any);
+
+    const result = await cancelRegistration({ eventId: 'event-1' });
+
+    expect(result).toEqual({ success: true });
+    expect(prismaMock.eventRegistration.update).toHaveBeenCalledTimes(1);
+    expect(revalidatePath).toHaveBeenCalledWith('/eventos/event-1');
+  });
+});

--- a/src/actions/events/check-event-capacity.test.ts
+++ b/src/actions/events/check-event-capacity.test.ts
@@ -1,0 +1,63 @@
+import { prismaMock } from '@/test/prisma';
+import { checkEventCapacity } from './check-event-capacity';
+
+const eventWithoutCapacity = {
+  id: 'event-1',
+  name: 'Tech Talk',
+  deletedAt: null,
+  capacity: null,
+};
+
+const eventWithCapacity = {
+  id: 'event-2',
+  name: 'Workshop',
+  deletedAt: null,
+  capacity: 10,
+};
+
+describe('checkEventCapacity', () => {
+  it('returns available: false when the event is not found', async () => {
+    prismaMock.event.findFirst.mockResolvedValue(null);
+
+    const result = await checkEventCapacity('non-existent');
+
+    expect(result).toEqual({ available: false, message: 'Evento no encontrado' });
+  });
+
+  it('returns available: true with null capacity when the event has no capacity limit', async () => {
+    prismaMock.event.findFirst.mockResolvedValue(eventWithoutCapacity as any);
+
+    const result = await checkEventCapacity('event-1');
+
+    expect(result).toEqual({ available: true, current: 0, capacity: null });
+    expect(prismaMock.eventRegistration.count).not.toHaveBeenCalled();
+  });
+
+  it('returns available: true when there are spots remaining', async () => {
+    prismaMock.event.findFirst.mockResolvedValue(eventWithCapacity as any);
+    prismaMock.eventRegistration.count.mockResolvedValue(6);
+
+    const result = await checkEventCapacity('event-2');
+
+    expect(result).toEqual({
+      available: true,
+      current: 6,
+      capacity: 10,
+      message: 'Quedan 4 lugares disponibles.',
+    });
+  });
+
+  it('returns available: false when the event is full', async () => {
+    prismaMock.event.findFirst.mockResolvedValue(eventWithCapacity as any);
+    prismaMock.eventRegistration.count.mockResolvedValue(10);
+
+    const result = await checkEventCapacity('event-2');
+
+    expect(result).toEqual({
+      available: false,
+      current: 10,
+      capacity: 10,
+      message: 'El cupo del evento está completo',
+    });
+  });
+});

--- a/src/actions/events/delete-event.test.ts
+++ b/src/actions/events/delete-event.test.ts
@@ -1,0 +1,101 @@
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { deleteEvent } from './delete-event';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const existingEvent = {
+  id: 'event-1',
+  name: 'Some Event',
+  deletedAt: null,
+};
+
+describe('deleteEvent', () => {
+  it('throws when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(deleteEvent('event-1')).rejects.toThrow('Usuario no autenticado');
+
+    expect(prismaMock.session.findUnique).not.toHaveBeenCalled();
+    expect(prismaMock.event.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'ghost-session' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(deleteEvent('event-1')).rejects.toThrow('Sesión no encontrada');
+
+    expect(prismaMock.event.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the user does not have ADMIN role', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue({
+      ...adminSession,
+      user: { ...adminUser, role: 'REGULAR' as const },
+    } as any);
+
+    await expect(deleteEvent('event-1')).rejects.toThrow(
+      'No tienes permisos para eliminar eventos',
+    );
+
+    expect(prismaMock.event.findUnique).not.toHaveBeenCalled();
+    expect(prismaMock.event.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the event is not found', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.event.findUnique.mockResolvedValue(null);
+
+    await expect(deleteEvent('event-1')).rejects.toThrow('Evento no encontrado');
+
+    expect(prismaMock.event.update).not.toHaveBeenCalled();
+  });
+
+  it('soft-deletes the event, revalidates /eventos, and redirects on success', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.event.findUnique.mockResolvedValue(existingEvent as any);
+    prismaMock.event.update.mockResolvedValue({ ...existingEvent, deletedAt: new Date() } as any);
+
+    await expect(deleteEvent('event-1')).rejects.toThrow('NEXT_REDIRECT:/eventos');
+
+    expect(prismaMock.event.update).toHaveBeenCalledTimes(1);
+    expect(revalidatePath).toHaveBeenCalledWith('/eventos');
+    expect(redirect).toHaveBeenCalledWith('/eventos');
+  });
+});

--- a/src/actions/events/delete-registration.test.ts
+++ b/src/actions/events/delete-registration.test.ts
@@ -1,0 +1,102 @@
+import { revalidatePath } from 'next/cache';
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { deleteRegistration } from './delete-registration';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const mockRegistration = {
+  id: 'reg-1',
+  eventId: 'event-1',
+  userId: 'user-admin',
+  cancelledAt: null,
+  createdAt: new Date('2025-06-01'),
+};
+
+describe('deleteRegistration', () => {
+  it('throws when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(deleteRegistration('reg-1')).rejects.toThrow('No autorizado');
+
+    expect(prismaMock.session.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found or user is not ADMIN', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue({
+      ...adminSession,
+      user: { ...adminUser, role: 'REGULAR' as const },
+    } as any);
+
+    await expect(deleteRegistration('reg-1')).rejects.toThrow(
+      'No tienes permisos para realizar esta acción',
+    );
+
+    expect(prismaMock.eventRegistration.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is null', async () => {
+    mockCookies({ sessionId: 'ghost-session' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(deleteRegistration('reg-1')).rejects.toThrow(
+      'No tienes permisos para realizar esta acción',
+    );
+  });
+
+  it('throws when the registration is not found', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.eventRegistration.findUnique.mockResolvedValue(null);
+
+    await expect(deleteRegistration('reg-1')).rejects.toThrow('Inscripción no encontrada');
+
+    expect(prismaMock.eventRegistration.delete).not.toHaveBeenCalled();
+  });
+
+  it('deletes the registration, revalidates the event path, and returns success', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.eventRegistration.findUnique.mockResolvedValue(mockRegistration as any);
+    prismaMock.eventRegistration.delete.mockResolvedValue(mockRegistration as any);
+
+    const result = await deleteRegistration('reg-1');
+
+    expect(result).toEqual({ success: true });
+    expect(prismaMock.eventRegistration.delete).toHaveBeenCalledWith({
+      where: { id: 'reg-1' },
+    });
+    expect(revalidatePath).toHaveBeenCalledWith('/eventos/event-1');
+  });
+});

--- a/src/actions/events/fetch-event-for-edit.test.ts
+++ b/src/actions/events/fetch-event-for-edit.test.ts
@@ -1,0 +1,30 @@
+import { prismaMock } from '@/test/prisma';
+import { fetchEventForEdit } from './fetch-event-for-edit';
+
+const mockEvent = {
+  id: 'event-1',
+  name: 'Tech Talk',
+  date: new Date('2026-08-15'),
+  deletedAt: new Date('2026-01-01'),
+  images: [],
+  sponsors: [],
+};
+
+describe('fetchEventForEdit', () => {
+  it('returns the event when found (including soft-deleted events)', async () => {
+    prismaMock.event.findUnique.mockResolvedValue(mockEvent as any);
+
+    const result = await fetchEventForEdit('event-1');
+
+    expect(result).toEqual(mockEvent);
+    expect(prismaMock.event.findUnique).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when the event does not exist', async () => {
+    prismaMock.event.findUnique.mockResolvedValue(null);
+
+    const result = await fetchEventForEdit('non-existent');
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/actions/events/fetch-event.test.ts
+++ b/src/actions/events/fetch-event.test.ts
@@ -1,0 +1,30 @@
+import { prismaMock } from '@/test/prisma';
+import { fetchEvent } from './fetch-event';
+
+const mockEvent = {
+  id: 'event-1',
+  name: 'Tech Talk',
+  date: new Date('2026-08-15'),
+  deletedAt: null,
+  images: [],
+  sponsors: [],
+};
+
+describe('fetchEvent', () => {
+  it('returns the event when found', async () => {
+    prismaMock.event.findFirst.mockResolvedValue(mockEvent as any);
+
+    const result = await fetchEvent('event-1');
+
+    expect(result).toEqual(mockEvent);
+    expect(prismaMock.event.findFirst).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when the event is not found', async () => {
+    prismaMock.event.findFirst.mockResolvedValue(null);
+
+    const result = await fetchEvent('non-existent');
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/actions/events/fetch-events.test.ts
+++ b/src/actions/events/fetch-events.test.ts
@@ -1,0 +1,29 @@
+import { prismaMock } from '@/test/prisma';
+import { fetchEvents } from './fetch-events';
+
+const mockEvent = {
+  id: 'event-1',
+  name: 'Tech Talk',
+  date: new Date('2026-08-15'),
+  deletedAt: null,
+  _count: { registrations: 5 },
+};
+
+describe('fetchEvents', () => {
+  it('returns the list of events from prisma', async () => {
+    prismaMock.event.findMany.mockResolvedValue([mockEvent] as any);
+
+    const result = await fetchEvents();
+
+    expect(result).toEqual([mockEvent]);
+    expect(prismaMock.event.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an empty array when there are no events', async () => {
+    prismaMock.event.findMany.mockResolvedValue([]);
+
+    const result = await fetchEvents();
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/actions/events/fetch-recently-added-events.test.ts
+++ b/src/actions/events/fetch-recently-added-events.test.ts
@@ -1,0 +1,37 @@
+import { prismaMock } from '@/test/prisma';
+import { fetchRecentlyAddedEvents } from './fetch-recently-added-events';
+
+const mockEvent = {
+  id: 'event-1',
+  name: 'Tech Talk',
+  date: new Date('2026-08-15'),
+  deletedAt: null,
+  _count: { registrations: 3 },
+};
+
+describe('fetchRecentlyAddedEvents', () => {
+  it('returns recently added events from prisma', async () => {
+    prismaMock.event.findMany.mockResolvedValue([mockEvent] as any);
+
+    const result = await fetchRecentlyAddedEvents();
+
+    expect(result).toEqual([mockEvent]);
+    expect(prismaMock.event.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an empty array when there are no events', async () => {
+    prismaMock.event.findMany.mockResolvedValue([]);
+
+    const result = await fetchRecentlyAddedEvents();
+
+    expect(result).toEqual([]);
+  });
+
+  it('fetches at most 3 events', async () => {
+    prismaMock.event.findMany.mockResolvedValue([]);
+
+    await fetchRecentlyAddedEvents();
+
+    expect(prismaMock.event.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 3 }));
+  });
+});

--- a/src/actions/events/fetch-upcoming-events.test.ts
+++ b/src/actions/events/fetch-upcoming-events.test.ts
@@ -1,0 +1,43 @@
+import { prismaMock } from '@/test/prisma';
+import { fetchUpcomingEvents } from './fetch-upcoming-events';
+
+const mockUpcomingEvent = {
+  id: 'event-1',
+  name: 'Tech Talk',
+  date: new Date('2026-08-15'),
+};
+
+describe('fetchUpcomingEvents', () => {
+  it('returns upcoming events from prisma', async () => {
+    prismaMock.event.findMany.mockResolvedValue([mockUpcomingEvent] as any);
+
+    const result = await fetchUpcomingEvents();
+
+    expect(result).toEqual([mockUpcomingEvent]);
+    expect(prismaMock.event.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an empty array when there are no upcoming events', async () => {
+    prismaMock.event.findMany.mockResolvedValue([]);
+
+    const result = await fetchUpcomingEvents();
+
+    expect(result).toEqual([]);
+  });
+
+  it('passes the limit to prisma when provided', async () => {
+    prismaMock.event.findMany.mockResolvedValue([]);
+
+    await fetchUpcomingEvents(10);
+
+    expect(prismaMock.event.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 10 }));
+  });
+
+  it('defaults to a limit of 5', async () => {
+    prismaMock.event.findMany.mockResolvedValue([]);
+
+    await fetchUpcomingEvents();
+
+    expect(prismaMock.event.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 5 }));
+  });
+});

--- a/src/actions/events/get-event-registrations.test.ts
+++ b/src/actions/events/get-event-registrations.test.ts
@@ -1,0 +1,52 @@
+import { prismaMock } from '@/test/prisma';
+import { getEventRegistrations } from './get-event-registrations';
+
+const mockUser = {
+  id: 'user-1',
+  name: 'Alice',
+  email: 'alice@example.com',
+  jobTitle: 'Engineer',
+  enterprise: 'Acme',
+  career: null,
+  studyPlace: null,
+};
+
+const mockRegistration = {
+  id: 'reg-1',
+  eventId: 'event-1',
+  userId: 'user-1',
+  cancelledAt: null,
+  createdAt: new Date('2025-06-01'),
+  user: mockUser,
+};
+
+describe('getEventRegistrations', () => {
+  it('returns mapped registration rows for the given event', async () => {
+    prismaMock.eventRegistration.findMany.mockResolvedValue([mockRegistration] as any);
+
+    const result = await getEventRegistrations('event-1');
+
+    expect(result).toEqual([
+      {
+        id: 'reg-1',
+        name: 'Alice',
+        email: 'alice@example.com',
+        jobTitle: 'Engineer',
+        enterprise: 'Acme',
+        career: null,
+        studyPlace: null,
+        cancelledAt: null,
+        createdAt: new Date('2025-06-01'),
+      },
+    ]);
+    expect(prismaMock.eventRegistration.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns an empty array when there are no registrations', async () => {
+    prismaMock.eventRegistration.findMany.mockResolvedValue([]);
+
+    const result = await getEventRegistrations('event-1');
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/actions/events/register-event.test.ts
+++ b/src/actions/events/register-event.test.ts
@@ -1,0 +1,118 @@
+import { revalidatePath } from 'next/cache';
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { registerEvent } from './register-event';
+
+jest.mock('@/actions/notifications/notify-admins', () => ({
+  notifyAdmins: jest.fn().mockResolvedValue(undefined),
+}));
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const mockEvent = {
+  id: 'event-1',
+  name: 'Tech Talk',
+  deletedAt: null,
+  capacity: null,
+};
+
+describe('registerEvent', () => {
+  it('throws when the event is not found', async () => {
+    prismaMock.event.findFirst.mockResolvedValue(null);
+
+    await expect(registerEvent('event-1')).rejects.toThrow('Evento no encontrado');
+
+    expect(prismaMock.session.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('throws when there is no sessionId cookie', async () => {
+    prismaMock.event.findFirst.mockResolvedValue(mockEvent as any);
+    mockCookies();
+
+    await expect(registerEvent('event-1')).rejects.toThrow(
+      'Debes estar autenticado para inscribirte a un evento',
+    );
+
+    expect(prismaMock.session.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    prismaMock.event.findFirst.mockResolvedValue(mockEvent as any);
+    mockCookies({ sessionId: 'ghost-session' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(registerEvent('event-1')).rejects.toThrow(
+      'Sesión no válida. Por favor, inicia sesión nuevamente',
+    );
+  });
+
+  it('throws when the user already has an active registration', async () => {
+    prismaMock.event.findFirst.mockResolvedValue(mockEvent as any);
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.eventRegistration.findFirst.mockResolvedValue({
+      id: 'reg-1',
+      cancelledAt: null,
+    } as any);
+
+    await expect(registerEvent('event-1')).rejects.toThrow('Ya estás registrado en este evento');
+
+    expect(prismaMock.eventRegistration.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a new registration and returns success when skipRedirect is true', async () => {
+    prismaMock.event.findFirst.mockResolvedValue(mockEvent as any);
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.eventRegistration.findFirst.mockResolvedValue(null);
+    prismaMock.eventRegistration.create.mockResolvedValue({ id: 'reg-1' } as any);
+
+    const result = await registerEvent('event-1', { skipRedirect: true });
+
+    expect(result).toEqual({ success: true, registrationId: 'reg-1' });
+    expect(prismaMock.eventRegistration.create).toHaveBeenCalledTimes(1);
+    expect(revalidatePath).toHaveBeenCalledWith('/eventos/event-1');
+  });
+
+  it('redirects to /eventos/EVENT_ID?registered=true on success', async () => {
+    prismaMock.event.findFirst.mockResolvedValue(mockEvent as any);
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.eventRegistration.findFirst.mockResolvedValue(null);
+    prismaMock.eventRegistration.create.mockResolvedValue({ id: 'reg-2' } as any);
+
+    await expect(registerEvent('event-1')).rejects.toThrow(
+      'NEXT_REDIRECT:/eventos/event-1?registered=true',
+    );
+  });
+});

--- a/src/actions/events/update-event.test.ts
+++ b/src/actions/events/update-event.test.ts
@@ -1,0 +1,114 @@
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import type { EventFormData } from '@/schemas/event-schema';
+import { updateEvent } from './update-event';
+
+const validEventData: EventFormData = {
+  name: 'Tech Talk Buenos Aires',
+  description: 'A great community event about modern software development.',
+  date: '2026-08-15T18:00:00.000Z',
+  isOnline: false,
+  city: 'Buenos Aires',
+  placeName: 'GCBA HQ',
+  address: 'Diagonal Norte 1234',
+  markedAsFull: false,
+  callForSpeakersEnabled: false,
+  shortcut: '',
+};
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const existingEvent = {
+  id: 'event-1',
+  name: 'Old Name',
+  deletedAt: null,
+};
+
+describe('updateEvent', () => {
+  it('throws when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(updateEvent('event-1', validEventData)).rejects.toThrow('Usuario no autenticado');
+
+    expect(prismaMock.session.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'ghost-session' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(updateEvent('event-1', validEventData)).rejects.toThrow('Sesión no encontrada');
+  });
+
+  it('throws when the user does not have ADMIN role', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue({
+      ...adminSession,
+      user: { ...adminUser, role: 'REGULAR' as const },
+    } as any);
+
+    await expect(updateEvent('event-1', validEventData)).rejects.toThrow(
+      'No tienes permisos para editar eventos',
+    );
+
+    expect(prismaMock.event.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('throws when the event is not found', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.event.findUnique.mockResolvedValue(null);
+
+    await expect(updateEvent('event-1', validEventData)).rejects.toThrow('Evento no encontrado');
+
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('updates the event, revalidates paths, and redirects on success', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.event.findUnique.mockResolvedValue(existingEvent as any);
+    prismaMock.$transaction.mockResolvedValue([undefined, undefined] as any);
+
+    await expect(updateEvent('event-1', validEventData)).rejects.toThrow(
+      'NEXT_REDIRECT:/eventos/event-1',
+    );
+
+    expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+    expect(revalidatePath).toHaveBeenCalledWith('/eventos');
+    expect(revalidatePath).toHaveBeenCalledWith('/eventos/event-1');
+    expect(redirect).toHaveBeenCalledWith('/eventos/event-1');
+  });
+});

--- a/src/actions/logs/fetch-logs.test.ts
+++ b/src/actions/logs/fetch-logs.test.ts
@@ -1,0 +1,121 @@
+import { prismaMock } from '@/test/prisma';
+import { fetchLogs, getLogStats } from './fetch-logs';
+
+const sampleLog = {
+  id: 'log-1',
+  level: 'info',
+  message: 'Test log',
+  path: '/home',
+  userId: null,
+  userAgent: null,
+  ipAddress: null,
+  metadata: null,
+  createdAt: new Date('2025-06-01'),
+  user: null,
+};
+
+describe('fetchLogs', () => {
+  it('uses default page=1 and limit=50 (skip=0, take=50)', async () => {
+    prismaMock.appLog.findMany.mockResolvedValue([sampleLog] as any);
+    prismaMock.appLog.count.mockResolvedValue(1);
+
+    const result = await fetchLogs();
+
+    expect(prismaMock.appLog.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 0, take: 50 }),
+    );
+    expect(result.pagination).toEqual({ page: 1, limit: 50, total: 1, totalPages: 1 });
+  });
+
+  it('calculates skip correctly for custom page and limit', async () => {
+    prismaMock.appLog.findMany.mockResolvedValue([] as any);
+    prismaMock.appLog.count.mockResolvedValue(200);
+
+    const result = await fetchLogs(3, 20);
+
+    expect(prismaMock.appLog.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 40, take: 20 }),
+    );
+    expect(result.pagination).toEqual({ page: 3, limit: 20, total: 200, totalPages: 10 });
+  });
+
+  it('passes a level filter to both findMany and count when provided', async () => {
+    prismaMock.appLog.findMany.mockResolvedValue([sampleLog] as any);
+    prismaMock.appLog.count.mockResolvedValue(1);
+
+    await fetchLogs(1, 50, 'error');
+
+    expect(prismaMock.appLog.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { level: 'error' } }),
+    );
+    expect(prismaMock.appLog.count).toHaveBeenCalledWith({ where: { level: 'error' } });
+  });
+
+  it('passes an empty where clause when no level is specified', async () => {
+    prismaMock.appLog.findMany.mockResolvedValue([] as any);
+    prismaMock.appLog.count.mockResolvedValue(0);
+
+    await fetchLogs(1, 50);
+
+    expect(prismaMock.appLog.findMany).toHaveBeenCalledWith(expect.objectContaining({ where: {} }));
+  });
+
+  it('includes user relation in the query', async () => {
+    prismaMock.appLog.findMany.mockResolvedValue([] as any);
+    prismaMock.appLog.count.mockResolvedValue(0);
+
+    await fetchLogs();
+
+    expect(prismaMock.appLog.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: { user: { select: { id: true, name: true, email: true } } },
+      }),
+    );
+  });
+
+  it('returns logs alongside pagination metadata', async () => {
+    prismaMock.appLog.findMany.mockResolvedValue([sampleLog] as any);
+    prismaMock.appLog.count.mockResolvedValue(1);
+
+    const result = await fetchLogs();
+
+    expect(result.logs).toHaveLength(1);
+    expect(result.logs[0]).toMatchObject({ id: 'log-1', level: 'info' });
+  });
+});
+
+describe('getLogStats', () => {
+  it('returns correct stats aggregating all prisma queries', async () => {
+    prismaMock.appLog.count
+      .mockResolvedValueOnce(100) // totalLogs
+      .mockResolvedValueOnce(5) // logsToday
+      .mockResolvedValueOnce(20); // logsThisWeek
+    prismaMock.appLog.groupBy.mockResolvedValue([
+      { level: 'info', _count: { level: 50 } },
+      { level: 'error', _count: { level: 30 } },
+      { level: 'warn', _count: { level: 15 } },
+      { level: 'debug', _count: { level: 5 } },
+    ] as any);
+
+    const result = await getLogStats();
+
+    expect(result).toEqual({
+      totalLogs: 100,
+      logsToday: 5,
+      logsThisWeek: 20,
+      logsByLevel: { info: 50, error: 30, warn: 15, debug: 5 },
+    });
+  });
+
+  it('defaults missing log levels to 0', async () => {
+    prismaMock.appLog.count
+      .mockResolvedValueOnce(10)
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(8);
+    prismaMock.appLog.groupBy.mockResolvedValue([{ level: 'info', _count: { level: 10 } }] as any);
+
+    const result = await getLogStats();
+
+    expect(result.logsByLevel).toEqual({ info: 10, warn: 0, error: 0, debug: 0 });
+  });
+});

--- a/src/actions/logs/log-client.test.ts
+++ b/src/actions/logs/log-client.test.ts
@@ -1,0 +1,143 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { mockHeaders } from '@/test/headers';
+import { logClient } from './log-client';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+const logData = { level: 'info' as const, message: 'Test message', path: '/home' };
+
+describe('logClient', () => {
+  it('creates an anonymous log when there is no session cookie', async () => {
+    mockCookies();
+    mockHeaders({ 'user-agent': 'Jest/1.0', 'x-forwarded-for': '1.2.3.4' });
+    prismaMock.appLog.create.mockResolvedValue({} as any);
+
+    await logClient(logData);
+
+    expect(prismaMock.appLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: null,
+          userAgent: 'Jest/1.0',
+          ipAddress: '1.2.3.4',
+        }),
+      }),
+    );
+  });
+
+  it('does not create a log for admin users', async () => {
+    mockCookies({ sessionId: adminSession.id });
+    mockHeaders({});
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+
+    await logClient(logData);
+
+    expect(prismaMock.appLog.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a log with userId for a regular user', async () => {
+    mockCookies({ sessionId: regularSession.id });
+    mockHeaders({ 'user-agent': 'Chrome/100', 'x-forwarded-for': '10.0.0.1' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+    prismaMock.appLog.create.mockResolvedValue({} as any);
+
+    await logClient(logData);
+
+    expect(prismaMock.appLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          userId: 'user-regular',
+          userAgent: 'Chrome/100',
+          ipAddress: '10.0.0.1',
+        }),
+      }),
+    );
+  });
+
+  it('falls back to x-real-ip when x-forwarded-for is absent', async () => {
+    mockCookies();
+    mockHeaders({ 'x-real-ip': '192.168.1.1' });
+    prismaMock.appLog.create.mockResolvedValue({} as any);
+
+    await logClient(logData);
+
+    expect(prismaMock.appLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ ipAddress: '192.168.1.1' }),
+      }),
+    );
+  });
+
+  it('stores null for user-agent and ip when headers are missing', async () => {
+    mockCookies();
+    mockHeaders({});
+    prismaMock.appLog.create.mockResolvedValue({} as any);
+
+    await logClient(logData);
+
+    expect(prismaMock.appLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ userAgent: null, ipAddress: null }),
+      }),
+    );
+  });
+
+  it('serialises metadata to JSON when provided', async () => {
+    mockCookies();
+    mockHeaders({});
+    prismaMock.appLog.create.mockResolvedValue({} as any);
+
+    await logClient({ ...logData, metadata: { key: 'value' } });
+
+    expect(prismaMock.appLog.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ metadata: JSON.stringify({ key: 'value' }) }),
+      }),
+    );
+  });
+
+  it('silences errors and does not throw', async () => {
+    mockCookies();
+    mockHeaders({});
+    prismaMock.appLog.create.mockRejectedValue(new Error('DB error'));
+
+    await expect(logClient(logData)).resolves.toBeUndefined();
+  });
+});

--- a/src/actions/notifications/fetch-notifications.test.ts
+++ b/src/actions/notifications/fetch-notifications.test.ts
@@ -1,0 +1,109 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { fetchNotifications } from './fetch-notifications';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const stubNotifications = [
+  {
+    id: 'notif-1',
+    type: 'NEW_EVENT',
+    title: 'New event',
+    message: 'An event was created',
+    userId: 'user-admin',
+    read: false,
+    metadata: null,
+    createdAt: new Date('2025-06-01'),
+    updatedAt: new Date('2025-06-01'),
+  },
+  {
+    id: 'notif-2',
+    type: 'NEW_EVENT',
+    title: 'Another event',
+    message: 'Another event was created',
+    userId: 'user-admin',
+    read: true,
+    metadata: null,
+    createdAt: new Date('2025-05-01'),
+    updatedAt: new Date('2025-05-01'),
+  },
+];
+
+describe('fetchNotifications', () => {
+  it('returns an empty array when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    const result = await fetchNotifications();
+
+    expect(result).toEqual([]);
+    expect(prismaMock.session.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty array when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    const result = await fetchNotifications();
+
+    expect(result).toEqual([]);
+    expect(prismaMock.notification.findMany).not.toHaveBeenCalled();
+  });
+
+  it('returns notifications for the current user ordered by createdAt desc', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.notification.findMany.mockResolvedValue(stubNotifications as any);
+
+    const result = await fetchNotifications();
+
+    expect(prismaMock.session.findUnique).toHaveBeenCalledWith({
+      where: { id: 'session-admin' },
+      include: { user: true },
+    });
+    expect(prismaMock.notification.findMany).toHaveBeenCalledWith({
+      where: { userId: 'user-admin' },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(result).toEqual(stubNotifications);
+  });
+
+  it('returns an empty array when the user has no notifications', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.notification.findMany.mockResolvedValue([]);
+
+    const result = await fetchNotifications();
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/actions/notifications/get-unread-count.test.ts
+++ b/src/actions/notifications/get-unread-count.test.ts
@@ -1,0 +1,97 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { getUnreadNotificationsCount } from './get-unread-count';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+describe('getUnreadNotificationsCount', () => {
+  it('returns 0 when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    const result = await getUnreadNotificationsCount();
+
+    expect(result).toBe(0);
+    expect(prismaMock.session.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    const result = await getUnreadNotificationsCount();
+
+    expect(result).toBe(0);
+    expect(prismaMock.notification.count).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 when the session user is not an ADMIN', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+
+    const result = await getUnreadNotificationsCount();
+
+    expect(result).toBe(0);
+    expect(prismaMock.notification.count).not.toHaveBeenCalled();
+  });
+
+  it('returns the unread notification count for an ADMIN user', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.notification.count.mockResolvedValue(5);
+
+    const result = await getUnreadNotificationsCount();
+
+    expect(prismaMock.notification.count).toHaveBeenCalledWith({
+      where: { userId: 'user-admin', read: false },
+    });
+    expect(result).toBe(5);
+  });
+
+  it('returns 0 when the ADMIN has no unread notifications', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.notification.count.mockResolvedValue(0);
+
+    const result = await getUnreadNotificationsCount();
+
+    expect(result).toBe(0);
+  });
+});

--- a/src/actions/notifications/mark-all-as-read.test.ts
+++ b/src/actions/notifications/mark-all-as-read.test.ts
@@ -1,0 +1,78 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import { markAllNotificationsAsRead } from './mark-all-as-read';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+describe('markAllNotificationsAsRead', () => {
+  it('throws "No autorizado" when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(markAllNotificationsAsRead()).rejects.toThrow('No autorizado');
+    expect(prismaMock.session.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('throws "No autorizado" when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(markAllNotificationsAsRead()).rejects.toThrow('No autorizado');
+    expect(prismaMock.notification.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('marks all unread notifications as read and revalidates the path on success', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.notification.updateMany.mockResolvedValue({ count: 3 });
+
+    await markAllNotificationsAsRead();
+
+    expect(prismaMock.notification.updateMany).toHaveBeenCalledWith({
+      where: { userId: 'user-admin', read: false },
+      data: { read: true },
+    });
+    expect(revalidatePath).toHaveBeenCalledWith('/notificaciones');
+  });
+
+  it('still revalidates the path when there are no unread notifications', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.notification.updateMany.mockResolvedValue({ count: 0 });
+
+    await markAllNotificationsAsRead();
+
+    expect(prismaMock.notification.updateMany).toHaveBeenCalled();
+    expect(revalidatePath).toHaveBeenCalledWith('/notificaciones');
+  });
+});

--- a/src/actions/notifications/mark-as-read.test.ts
+++ b/src/actions/notifications/mark-as-read.test.ts
@@ -1,0 +1,105 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import { markNotificationAsRead } from './mark-as-read';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const stubNotification = {
+  id: 'notif-1',
+  type: 'NEW_EVENT',
+  title: 'New event',
+  message: 'An event was created',
+  userId: 'user-admin',
+  read: false,
+  metadata: null,
+  createdAt: new Date('2025-06-01'),
+  updatedAt: new Date('2025-06-01'),
+};
+
+describe('markNotificationAsRead', () => {
+  it('throws "No autorizado" when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(markNotificationAsRead('notif-1')).rejects.toThrow('No autorizado');
+    expect(prismaMock.session.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('throws "No autorizado" when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(markNotificationAsRead('notif-1')).rejects.toThrow('No autorizado');
+    expect(prismaMock.notification.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('throws when the notification does not exist', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.notification.findUnique.mockResolvedValue(null);
+
+    await expect(markNotificationAsRead('notif-1')).rejects.toThrow(
+      'No tienes permisos para marcar esta notificación como leída',
+    );
+    expect(prismaMock.notification.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the notification belongs to a different user', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.notification.findUnique.mockResolvedValue({
+      ...stubNotification,
+      userId: 'user-other',
+    } as any);
+
+    await expect(markNotificationAsRead('notif-1')).rejects.toThrow(
+      'No tienes permisos para marcar esta notificación como leída',
+    );
+    expect(prismaMock.notification.update).not.toHaveBeenCalled();
+  });
+
+  it('marks the notification as read and revalidates the path on success', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.notification.findUnique.mockResolvedValue(stubNotification as any);
+    prismaMock.notification.update.mockResolvedValue({ ...stubNotification, read: true } as any);
+
+    await markNotificationAsRead('notif-1');
+
+    expect(prismaMock.notification.update).toHaveBeenCalledWith({
+      where: { id: 'notif-1' },
+      data: { read: true },
+    });
+    expect(revalidatePath).toHaveBeenCalledWith('/notificaciones');
+  });
+});

--- a/src/actions/notifications/notify-admins.test.ts
+++ b/src/actions/notifications/notify-admins.test.ts
@@ -1,0 +1,70 @@
+import { prismaMock } from '@/test/prisma';
+import { notifyAdmins } from './notify-admins';
+
+const notificationData = {
+  type: 'NEW_EVENT',
+  title: 'New event created',
+  message: 'A new event has been added.',
+};
+
+const notificationDataWithMetadata = {
+  ...notificationData,
+  metadata: { eventId: 'event-1' },
+};
+
+describe('notifyAdmins', () => {
+  it('creates a notification for each admin user', async () => {
+    prismaMock.user.findMany.mockResolvedValue([{ id: 'admin-1' }, { id: 'admin-2' }] as any);
+    prismaMock.notification.createMany.mockResolvedValue({ count: 2 });
+
+    await notifyAdmins(notificationData);
+
+    expect(prismaMock.user.findMany).toHaveBeenCalledWith({
+      where: { role: 'ADMIN' },
+      select: { id: true },
+    });
+    expect(prismaMock.notification.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          type: 'NEW_EVENT',
+          title: 'New event created',
+          message: 'A new event has been added.',
+          userId: 'admin-1',
+          metadata: null,
+        },
+        {
+          type: 'NEW_EVENT',
+          title: 'New event created',
+          message: 'A new event has been added.',
+          userId: 'admin-2',
+          metadata: null,
+        },
+      ],
+    });
+  });
+
+  it('serialises metadata as JSON string when provided', async () => {
+    prismaMock.user.findMany.mockResolvedValue([{ id: 'admin-1' }] as any);
+    prismaMock.notification.createMany.mockResolvedValue({ count: 1 });
+
+    await notifyAdmins(notificationDataWithMetadata);
+
+    expect(prismaMock.notification.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          userId: 'admin-1',
+          metadata: JSON.stringify({ eventId: 'event-1' }),
+        }),
+      ],
+    });
+  });
+
+  it('calls createMany with an empty array when there are no admins', async () => {
+    prismaMock.user.findMany.mockResolvedValue([]);
+    prismaMock.notification.createMany.mockResolvedValue({ count: 0 });
+
+    await notifyAdmins(notificationData);
+
+    expect(prismaMock.notification.createMany).toHaveBeenCalledWith({ data: [] });
+  });
+});

--- a/src/actions/talk-proposals/create-talk-proposal.test.ts
+++ b/src/actions/talk-proposals/create-talk-proposal.test.ts
@@ -1,0 +1,143 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import { createTalkProposal } from './create-talk-proposal';
+import type { TalkProposalFormData } from '@/schemas/talk-proposal-schema';
+
+jest.mock('@/actions/notifications/notify-admins', () => ({
+  notifyAdmins: jest.fn().mockResolvedValue(undefined),
+}));
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const mockEvent = {
+  id: 'event-1',
+  name: 'Tech Talk BA',
+  deletedAt: null,
+  callForSpeakersEnabled: true,
+};
+
+const validData: TalkProposalFormData = {
+  title: 'Mi charla sobre testing',
+  description: 'Una descripción detallada sobre testing en Next.js con Jest.',
+  speakers: [
+    {
+      userId: null,
+      speakerName: 'Juan Pérez',
+      speakerPhone: '5493815123456',
+      isProfessional: true,
+      jobTitle: 'Engineer',
+      enterprise: 'Acme',
+      isStudent: false,
+      career: undefined,
+      studyPlace: undefined,
+    },
+  ],
+};
+
+describe('createTalkProposal', () => {
+  it('throws when the event is not found', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.event.findFirst.mockResolvedValue(null);
+
+    await expect(createTalkProposal('event-1', validData)).rejects.toThrow('Evento no encontrado');
+
+    expect(prismaMock.talkProposal.create).not.toHaveBeenCalled();
+  });
+
+  it('throws when call for speakers is not enabled', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.event.findFirst.mockResolvedValue({
+      ...mockEvent,
+      callForSpeakersEnabled: false,
+    } as any);
+
+    await expect(createTalkProposal('event-1', validData)).rejects.toThrow(
+      'Este evento no tiene call for speakers habilitado',
+    );
+
+    expect(prismaMock.talkProposal.create).not.toHaveBeenCalled();
+  });
+
+  it('throws when there is no sessionId cookie', async () => {
+    mockCookies();
+    prismaMock.event.findFirst.mockResolvedValue(mockEvent as any);
+
+    await expect(createTalkProposal('event-1', validData)).rejects.toThrow(
+      'Debes estar autenticado para proponer una charla',
+    );
+
+    expect(prismaMock.talkProposal.create).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'ghost-session' });
+    prismaMock.event.findFirst.mockResolvedValue(mockEvent as any);
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(createTalkProposal('event-1', validData)).rejects.toThrow(
+      'Sesión no válida. Por favor, inicia sesión nuevamente',
+    );
+
+    expect(prismaMock.talkProposal.create).not.toHaveBeenCalled();
+  });
+
+  it('throws when data fails schema validation', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.event.findFirst.mockResolvedValue(mockEvent as any);
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+
+    const invalidData: TalkProposalFormData = {
+      title: 'ok',
+      description: 'short',
+      speakers: [],
+    };
+
+    await expect(createTalkProposal('event-1', invalidData)).rejects.toThrow();
+
+    expect(prismaMock.talkProposal.create).not.toHaveBeenCalled();
+  });
+
+  it('creates the proposal, revalidates the path, and returns success', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.event.findFirst.mockResolvedValue(mockEvent as any);
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.talkProposal.create.mockResolvedValue({ id: 'proposal-1' } as any);
+
+    const result = await createTalkProposal('event-1', validData);
+
+    expect(result).toEqual({ success: true, proposalId: 'proposal-1' });
+    expect(prismaMock.talkProposal.create).toHaveBeenCalledTimes(1);
+    expect(revalidatePath).toHaveBeenCalledWith('/eventos/event-1/propuestas-de-charlas');
+  });
+});

--- a/src/actions/talk-proposals/delete-talk-proposal.test.ts
+++ b/src/actions/talk-proposals/delete-talk-proposal.test.ts
@@ -1,0 +1,101 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import { deleteTalkProposal } from './delete-talk-proposal';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+const mockProposal = { id: 'proposal-1', eventId: 'event-1' };
+
+describe('deleteTalkProposal', () => {
+  it('throws when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(deleteTalkProposal('proposal-1')).rejects.toThrow('Debes estar autenticado');
+
+    expect(prismaMock.talkProposal.delete).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'ghost-session' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(deleteTalkProposal('proposal-1')).rejects.toThrow(
+      'No tenés permisos para realizar esta acción',
+    );
+
+    expect(prismaMock.talkProposal.delete).not.toHaveBeenCalled();
+  });
+
+  it('throws when the user does not have ADMIN role', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+
+    await expect(deleteTalkProposal('proposal-1')).rejects.toThrow(
+      'No tenés permisos para realizar esta acción',
+    );
+
+    expect(prismaMock.talkProposal.delete).not.toHaveBeenCalled();
+  });
+
+  it('throws when the proposal is not found', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.talkProposal.findUnique.mockResolvedValue(null);
+
+    await expect(deleteTalkProposal('proposal-1')).rejects.toThrow('Propuesta no encontrada');
+
+    expect(prismaMock.talkProposal.delete).not.toHaveBeenCalled();
+  });
+
+  it('deletes the proposal, revalidates the path, and returns success', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.talkProposal.findUnique.mockResolvedValue(mockProposal as any);
+    prismaMock.talkProposal.delete.mockResolvedValue(mockProposal as any);
+
+    const result = await deleteTalkProposal('proposal-1');
+
+    expect(result).toEqual({ success: true });
+    expect(prismaMock.talkProposal.delete).toHaveBeenCalledWith({ where: { id: 'proposal-1' } });
+    expect(revalidatePath).toHaveBeenCalledWith('/eventos/event-1/propuestas-de-charlas');
+  });
+});

--- a/src/actions/talk-proposals/fetch-talk-proposals.test.ts
+++ b/src/actions/talk-proposals/fetch-talk-proposals.test.ts
@@ -1,0 +1,58 @@
+import { prismaMock } from '@/test/prisma';
+import { fetchTalkProposals } from './fetch-talk-proposals';
+
+const mockProposals = [
+  {
+    id: 'proposal-1',
+    eventId: 'event-1',
+    userId: 'user-1',
+    title: 'Charla sobre React',
+    description: 'Una introducción a React',
+    status: 'PENDING',
+    createdAt: new Date('2025-06-01'),
+    updatedAt: new Date('2025-06-01'),
+    talk: null,
+    speakers: [],
+  },
+  {
+    id: 'proposal-2',
+    eventId: 'event-1',
+    userId: 'user-2',
+    title: 'Testing con Jest',
+    description: 'Cómo hacer unit tests en Next.js',
+    status: 'APPROVED',
+    createdAt: new Date('2025-06-02'),
+    updatedAt: new Date('2025-06-02'),
+    talk: { id: 'talk-1' },
+    speakers: [],
+  },
+];
+
+describe('fetchTalkProposals', () => {
+  it('returns proposals for the given event ordered by createdAt desc', async () => {
+    prismaMock.talkProposal.findMany.mockResolvedValue(mockProposals as any);
+
+    const result = await fetchTalkProposals('event-1');
+
+    expect(result).toEqual(mockProposals);
+    expect(prismaMock.talkProposal.findMany).toHaveBeenCalledWith({
+      where: { eventId: 'event-1' },
+      orderBy: { createdAt: 'desc' },
+      include: {
+        talk: { select: { id: true } },
+        speakers: { orderBy: { order: 'asc' } },
+      },
+    });
+  });
+
+  it('returns an empty array when there are no proposals for the event', async () => {
+    prismaMock.talkProposal.findMany.mockResolvedValue([]);
+
+    const result = await fetchTalkProposals('event-empty');
+
+    expect(result).toEqual([]);
+    expect(prismaMock.talkProposal.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { eventId: 'event-empty' } }),
+    );
+  });
+});

--- a/src/actions/talk-proposals/update-talk-proposal-status.test.ts
+++ b/src/actions/talk-proposals/update-talk-proposal-status.test.ts
@@ -1,0 +1,115 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import { updateTalkProposalStatus } from './update-talk-proposal-status';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+describe('updateTalkProposalStatus', () => {
+  it('throws when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(updateTalkProposalStatus('proposal-1', 'APPROVED')).rejects.toThrow(
+      'Debes estar autenticado',
+    );
+
+    expect(prismaMock.talkProposal.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'ghost-session' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(updateTalkProposalStatus('proposal-1', 'APPROVED')).rejects.toThrow(
+      'No tenés permisos para realizar esta acción',
+    );
+
+    expect(prismaMock.talkProposal.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the user does not have ADMIN role', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+
+    await expect(updateTalkProposalStatus('proposal-1', 'APPROVED')).rejects.toThrow(
+      'No tenés permisos para realizar esta acción',
+    );
+
+    expect(prismaMock.talkProposal.update).not.toHaveBeenCalled();
+  });
+
+  it('updates the status, revalidates the path, and returns success', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.talkProposal.update.mockResolvedValue({
+      id: 'proposal-1',
+      eventId: 'event-1',
+      status: 'APPROVED',
+    } as any);
+
+    const result = await updateTalkProposalStatus('proposal-1', 'APPROVED');
+
+    expect(result).toEqual({ success: true });
+    expect(prismaMock.talkProposal.update).toHaveBeenCalledWith({
+      where: { id: 'proposal-1' },
+      data: { status: 'APPROVED' },
+    });
+    expect(revalidatePath).toHaveBeenCalledWith('/eventos/event-1/propuestas-de-charlas');
+  });
+
+  it('updates to REJECTED status', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.talkProposal.update.mockResolvedValue({
+      id: 'proposal-2',
+      eventId: 'event-2',
+      status: 'REJECTED',
+    } as any);
+
+    const result = await updateTalkProposalStatus('proposal-2', 'REJECTED');
+
+    expect(result).toEqual({ success: true });
+    expect(prismaMock.talkProposal.update).toHaveBeenCalledWith({
+      where: { id: 'proposal-2' },
+      data: { status: 'REJECTED' },
+    });
+  });
+});

--- a/src/actions/talks/create-talk-from-proposal.test.ts
+++ b/src/actions/talks/create-talk-from-proposal.test.ts
@@ -1,0 +1,126 @@
+import { createTalkFromProposal } from './create-talk-from-proposal';
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+const PROPOSAL_ID = 'proposal-1';
+const EVENT_ID = 'cTestEventId1234';
+
+const baseProposal = {
+  id: PROPOSAL_ID,
+  eventId: EVENT_ID,
+  title: 'Proposal Title',
+  description: 'Proposal description.',
+  talk: null,
+  speakers: [
+    {
+      id: 'speaker-1',
+      userId: null,
+      speakerName: 'Alice',
+      speakerPhone: '',
+      isProfessional: true,
+      jobTitle: 'Dev',
+      enterprise: 'Corp',
+      isStudent: false,
+      career: null,
+      studyPlace: null,
+      order: 0,
+    },
+  ],
+};
+
+describe('createTalkFromProposal', () => {
+  it('throws when no sessionId cookie is present', async () => {
+    mockCookies();
+    await expect(createTalkFromProposal(PROPOSAL_ID)).rejects.toThrow('Debes estar autenticado');
+  });
+
+  it('throws when session is not found in db', async () => {
+    mockCookies({ sessionId: 'session-x' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+    await expect(createTalkFromProposal(PROPOSAL_ID)).rejects.toThrow(
+      'No tenés permisos para realizar esta acción',
+    );
+  });
+
+  it('throws when user role is not ADMIN', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+    await expect(createTalkFromProposal(PROPOSAL_ID)).rejects.toThrow(
+      'No tenés permisos para realizar esta acción',
+    );
+  });
+
+  it('throws when proposal is not found', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.talkProposal.findUnique.mockResolvedValue(null);
+    await expect(createTalkFromProposal(PROPOSAL_ID)).rejects.toThrow('Propuesta no encontrada');
+  });
+
+  it('returns alreadyExists true when proposal already has a talk', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.talkProposal.findUnique.mockResolvedValue({
+      ...baseProposal,
+      talk: { id: 'existing-talk' },
+    } as any);
+
+    const result = await createTalkFromProposal(PROPOSAL_ID);
+
+    expect(result).toEqual({ success: true, talkId: 'existing-talk', alreadyExists: true });
+    expect(prismaMock.talk.create).not.toHaveBeenCalled();
+  });
+
+  it('creates talk and revalidates paths on success', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.talkProposal.findUnique.mockResolvedValue(baseProposal as any);
+    prismaMock.talk.create.mockResolvedValue({ id: 'new-talk' } as any);
+
+    const result = await createTalkFromProposal(PROPOSAL_ID);
+
+    expect(result).toEqual({ success: true, talkId: 'new-talk', alreadyExists: false });
+    expect(revalidatePath).toHaveBeenCalledWith(`/eventos/${EVENT_ID}/charlas`);
+    expect(revalidatePath).toHaveBeenCalledWith(`/eventos/${EVENT_ID}/propuestas-de-charlas`);
+    expect(revalidatePath).toHaveBeenCalledWith('/charlas');
+  });
+});

--- a/src/actions/talks/create-talk.test.ts
+++ b/src/actions/talks/create-talk.test.ts
@@ -1,0 +1,117 @@
+import { createTalk } from './create-talk';
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import type { TalkFormData } from '@/schemas/talk-schema';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+// Valid CUID: starts with 'c', at least 8 non-space non-hyphen chars after it
+const EVENT_ID = 'cTestEventId1234';
+
+const validData: TalkFormData = {
+  title: 'Test Talk Title',
+  description: 'A description with at least ten characters.',
+  speakers: [
+    {
+      speakerName: 'John Doe',
+      isProfessional: true,
+      jobTitle: 'Developer',
+      enterprise: 'Acme Corp',
+      isStudent: false,
+    },
+  ],
+  order: 0,
+};
+
+describe('createTalk', () => {
+  it('throws when no sessionId cookie is present', async () => {
+    mockCookies();
+    await expect(createTalk(validData)).rejects.toThrow('Debes estar autenticado');
+  });
+
+  it('throws when session is not found in db', async () => {
+    mockCookies({ sessionId: 'session-x' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+    await expect(createTalk(validData)).rejects.toThrow(
+      'No tenés permisos para realizar esta acción',
+    );
+  });
+
+  it('throws when user role is not ADMIN', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+    await expect(createTalk(validData)).rejects.toThrow(
+      'No tenés permisos para realizar esta acción',
+    );
+  });
+
+  it('throws a validation error when schema parsing fails', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    const invalidData: TalkFormData = { ...validData, title: 'ab' }; // too short (< 3 chars)
+    await expect(createTalk(invalidData)).rejects.toThrow(
+      'El título debe tener al menos 3 caracteres',
+    );
+  });
+
+  it('creates talk and revalidates /charlas when no eventId is given', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.talk.create.mockResolvedValue({ id: 'talk-1' } as any);
+
+    const result = await createTalk(validData);
+
+    expect(result).toEqual({ success: true, talkId: 'talk-1' });
+    expect(revalidatePath).toHaveBeenCalledWith('/charlas');
+    expect(revalidatePath).not.toHaveBeenCalledWith(expect.stringContaining('/eventos'));
+  });
+
+  it('revalidates event-specific path when eventId is provided', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.talk.create.mockResolvedValue({ id: 'talk-2' } as any);
+
+    const result = await createTalk({ ...validData, eventId: EVENT_ID });
+
+    expect(result).toEqual({ success: true, talkId: 'talk-2' });
+    expect(revalidatePath).toHaveBeenCalledWith(`/eventos/${EVENT_ID}/charlas`);
+    expect(revalidatePath).toHaveBeenCalledWith('/charlas');
+  });
+});

--- a/src/actions/talks/delete-talk.test.ts
+++ b/src/actions/talks/delete-talk.test.ts
@@ -1,0 +1,101 @@
+import { deleteTalk } from './delete-talk';
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+const TALK_ID = 'talk-1';
+const EVENT_ID = 'cTestEventId1234';
+
+describe('deleteTalk', () => {
+  it('throws when no sessionId cookie is present', async () => {
+    mockCookies();
+    await expect(deleteTalk(TALK_ID)).rejects.toThrow('Debes estar autenticado');
+  });
+
+  it('throws when session is not found in db', async () => {
+    mockCookies({ sessionId: 'session-x' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+    await expect(deleteTalk(TALK_ID)).rejects.toThrow(
+      'No tenés permisos para realizar esta acción',
+    );
+  });
+
+  it('throws when user role is not ADMIN', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+    await expect(deleteTalk(TALK_ID)).rejects.toThrow(
+      'No tenés permisos para realizar esta acción',
+    );
+  });
+
+  it('throws when talk does not exist', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.talk.findUnique.mockResolvedValue(null);
+    await expect(deleteTalk(TALK_ID)).rejects.toThrow('Charla no encontrada');
+  });
+
+  it('deletes talk and revalidates /charlas when talk has no eventId', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.talk.findUnique.mockResolvedValue({ id: TALK_ID, eventId: null } as any);
+    prismaMock.talk.delete.mockResolvedValue({ id: TALK_ID } as any);
+
+    const result = await deleteTalk(TALK_ID);
+
+    expect(result).toEqual({ success: true });
+    expect(revalidatePath).toHaveBeenCalledWith('/charlas');
+    expect(revalidatePath).not.toHaveBeenCalledWith(expect.stringContaining('/eventos'));
+  });
+
+  it('revalidates event-specific path when talk has an eventId', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.talk.findUnique.mockResolvedValue({ id: TALK_ID, eventId: EVENT_ID } as any);
+    prismaMock.talk.delete.mockResolvedValue({ id: TALK_ID } as any);
+
+    const result = await deleteTalk(TALK_ID);
+
+    expect(result).toEqual({ success: true });
+    expect(revalidatePath).toHaveBeenCalledWith(`/eventos/${EVENT_ID}/charlas`);
+    expect(revalidatePath).toHaveBeenCalledWith('/charlas');
+  });
+});

--- a/src/actions/talks/fetch-events-for-select.test.ts
+++ b/src/actions/talks/fetch-events-for-select.test.ts
@@ -1,0 +1,45 @@
+import { fetchEventsForSelect } from './fetch-events-for-select';
+import { prismaMock } from '@/test/prisma';
+
+const events = [
+  {
+    id: 'event-1',
+    name: 'Event One',
+    date: new Date('2025-06-01'),
+    placeName: 'Venue A',
+    city: 'Buenos Aires',
+    isOnline: false,
+  },
+  {
+    id: 'event-2',
+    name: 'Event Two',
+    date: new Date('2025-01-01'),
+    placeName: null,
+    city: 'Córdoba',
+    isOnline: true,
+  },
+];
+
+describe('fetchEventsForSelect', () => {
+  it('returns events ordered by date descending', async () => {
+    prismaMock.event.findMany.mockResolvedValue(events as any);
+
+    const result = await fetchEventsForSelect();
+
+    expect(result).toEqual(events);
+    expect(prismaMock.event.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { deletedAt: null },
+        orderBy: { date: 'desc' },
+      }),
+    );
+  });
+
+  it('returns an empty array when no events exist', async () => {
+    prismaMock.event.findMany.mockResolvedValue([]);
+
+    const result = await fetchEventsForSelect();
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/actions/talks/fetch-public-talks.test.ts
+++ b/src/actions/talks/fetch-public-talks.test.ts
@@ -1,0 +1,91 @@
+import { fetchPublicTalks } from './fetch-public-talks';
+import { prismaMock } from '@/test/prisma';
+
+const makeDate = (iso: string) => new Date(iso);
+
+const talkWithEvent = (id: string, eventDate: string) => ({
+  id,
+  title: `Talk ${id}`,
+  createdAt: makeDate('2025-01-01'),
+  manualEventDate: null,
+  event: {
+    id: `event-${id}`,
+    name: 'Some Event',
+    date: makeDate(eventDate),
+    placeName: 'Place',
+    city: 'City',
+    isOnline: false,
+  },
+  speakers: [],
+});
+
+const talkWithManualDate = (id: string, manualDate: string) => ({
+  id,
+  title: `Talk ${id}`,
+  createdAt: makeDate('2025-01-01'),
+  manualEventDate: makeDate(manualDate),
+  event: null,
+  speakers: [],
+});
+
+const talkWithNoDate = (id: string, createdAt: string) => ({
+  id,
+  title: `Talk ${id}`,
+  createdAt: makeDate(createdAt),
+  manualEventDate: null,
+  event: null,
+  speakers: [],
+});
+
+describe('fetchPublicTalks', () => {
+  it('returns an empty array when there are no talks', async () => {
+    prismaMock.talk.findMany.mockResolvedValue([]);
+    const result = await fetchPublicTalks();
+    expect(result).toEqual([]);
+  });
+
+  it('sorts talks by event date descending', async () => {
+    const older = talkWithEvent('older', '2024-01-01');
+    const newer = talkWithEvent('newer', '2025-06-01');
+    prismaMock.talk.findMany.mockResolvedValue([older, newer] as any);
+
+    const result = await fetchPublicTalks();
+
+    expect(result[0].id).toBe('newer');
+    expect(result[1].id).toBe('older');
+  });
+
+  it('places talks with a date before talks without a date', async () => {
+    const withDate = talkWithEvent('withDate', '2024-01-01');
+    const noDate = talkWithNoDate('noDate', '2025-06-01');
+    prismaMock.talk.findMany.mockResolvedValue([noDate, withDate] as any);
+
+    const result = await fetchPublicTalks();
+
+    expect(result[0].id).toBe('withDate');
+    expect(result[1].id).toBe('noDate');
+  });
+
+  it('sorts talks without any date by createdAt descending', async () => {
+    const older = talkWithNoDate('older', '2024-01-01');
+    const newer = talkWithNoDate('newer', '2025-06-01');
+    prismaMock.talk.findMany.mockResolvedValue([older, newer] as any);
+
+    const result = await fetchPublicTalks();
+
+    expect(result[0].id).toBe('newer');
+    expect(result[1].id).toBe('older');
+  });
+
+  it('uses manualEventDate when event is null', async () => {
+    const manual = talkWithManualDate('manual', '2025-03-01');
+    const withEvent = talkWithEvent('withEvent', '2024-01-01');
+    prismaMock.talk.findMany.mockResolvedValue([withEvent, manual] as any);
+
+    const result = await fetchPublicTalks();
+
+    // manual (2025-03-01) is newer than withEvent (2024-01-01)
+    expect(result[0].id).toBe('manual');
+    expect(result[1].id).toBe('withEvent');
+  });
+});

--- a/src/actions/talks/fetch-talks.test.ts
+++ b/src/actions/talks/fetch-talks.test.ts
@@ -1,0 +1,40 @@
+import { fetchTalks } from './fetch-talks';
+import { prismaMock } from '@/test/prisma';
+
+const talks = [
+  { id: 'talk-1', title: 'Talk One', order: 0, createdAt: new Date('2025-01-01'), speakers: [] },
+  { id: 'talk-2', title: 'Talk Two', order: 1, createdAt: new Date('2025-01-02'), speakers: [] },
+];
+
+describe('fetchTalks', () => {
+  it('returns all talks when no eventId is given', async () => {
+    prismaMock.talk.findMany.mockResolvedValue(talks as any);
+
+    const result = await fetchTalks();
+
+    expect(result).toEqual(talks);
+    expect(prismaMock.talk.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: undefined }),
+    );
+  });
+
+  it('filters talks by eventId when provided', async () => {
+    const filtered = [talks[0]];
+    prismaMock.talk.findMany.mockResolvedValue(filtered as any);
+
+    const result = await fetchTalks('event-1');
+
+    expect(result).toEqual(filtered);
+    expect(prismaMock.talk.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { eventId: 'event-1' } }),
+    );
+  });
+
+  it('returns an empty array when no talks exist', async () => {
+    prismaMock.talk.findMany.mockResolvedValue([]);
+
+    const result = await fetchTalks();
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/actions/talks/update-talk.test.ts
+++ b/src/actions/talks/update-talk.test.ts
@@ -1,0 +1,126 @@
+import { updateTalk } from './update-talk';
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import type { TalkFormData } from '@/schemas/talk-schema';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+const TALK_ID = 'talk-1';
+const EVENT_ID = 'cTestEventId1234';
+
+const existingTalk = {
+  id: TALK_ID,
+  eventId: EVENT_ID,
+  title: 'Old Title',
+  description: 'Old description text here.',
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const validData: TalkFormData = {
+  title: 'Updated Talk Title',
+  description: 'An updated description with enough characters.',
+  speakers: [
+    {
+      speakerName: 'Jane Doe',
+      isProfessional: true,
+      jobTitle: 'Engineer',
+      enterprise: 'Tech Corp',
+      isStudent: false,
+    },
+  ],
+  order: 1,
+};
+
+describe('updateTalk', () => {
+  it('throws when no sessionId cookie is present', async () => {
+    mockCookies();
+    await expect(updateTalk(TALK_ID, validData)).rejects.toThrow('Debes estar autenticado');
+  });
+
+  it('throws when session is not found in db', async () => {
+    mockCookies({ sessionId: 'session-x' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+    await expect(updateTalk(TALK_ID, validData)).rejects.toThrow(
+      'No tenés permisos para realizar esta acción',
+    );
+  });
+
+  it('throws when user role is not ADMIN', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+    await expect(updateTalk(TALK_ID, validData)).rejects.toThrow(
+      'No tenés permisos para realizar esta acción',
+    );
+  });
+
+  it('throws when talk does not exist', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.talk.findUnique.mockResolvedValue(null);
+    await expect(updateTalk(TALK_ID, validData)).rejects.toThrow('Charla no encontrada');
+  });
+
+  it('updates talk and revalidates paths on success', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.talk.findUnique.mockResolvedValue(existingTalk as any);
+    prismaMock.$transaction.mockResolvedValue([{}, { count: 0 }, { count: 1 }] as any);
+
+    const result = await updateTalk(TALK_ID, validData);
+
+    expect(result).toEqual({ success: true });
+    expect(revalidatePath).toHaveBeenCalledWith('/charlas');
+    expect(revalidatePath).toHaveBeenCalledWith(`/eventos/${EVENT_ID}/charlas`);
+  });
+
+  it('falls back to existing eventId for revalidation when new data has no eventId', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.talk.findUnique.mockResolvedValue(existingTalk as any);
+    prismaMock.$transaction.mockResolvedValue([{}, { count: 0 }, { count: 1 }] as any);
+
+    // validData has no eventId, so existing.eventId should be used
+    await updateTalk(TALK_ID, validData);
+
+    expect(revalidatePath).toHaveBeenCalledWith(`/eventos/${EVENT_ID}/charlas`);
+    expect(revalidatePath).toHaveBeenCalledWith('/charlas');
+  });
+});

--- a/src/actions/testimonials/create-testimonial.test.ts
+++ b/src/actions/testimonials/create-testimonial.test.ts
@@ -1,0 +1,76 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import { createTestimonial } from './create-testimonial';
+
+jest.mock('@/actions/notifications/notify-admins', () => ({
+  notifyAdmins: jest.fn().mockResolvedValue(undefined),
+}));
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const validData = { body: 'This is a valid testimonial body.' };
+
+describe('createTestimonial', () => {
+  it('throws when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(createTestimonial(validData)).rejects.toThrow(
+      'Debes estar autenticado para crear un testimonio',
+    );
+    expect(prismaMock.testimonial.create).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(createTestimonial(validData)).rejects.toThrow('Sesión no encontrada');
+    expect(prismaMock.testimonial.create).not.toHaveBeenCalled();
+  });
+
+  it('creates the testimonial and revalidates the path on success', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    const createdTestimonial = { id: 'test-1', body: validData.body, userId: 'user-admin' };
+    prismaMock.testimonial.create.mockResolvedValue(createdTestimonial as any);
+    prismaMock.user.findUnique.mockResolvedValue(adminUser as any);
+
+    await createTestimonial(validData);
+
+    expect(prismaMock.testimonial.create).toHaveBeenCalledWith({
+      data: { body: validData.body, userId: 'user-admin' },
+    });
+    expect(revalidatePath).toHaveBeenCalledWith('/testimonios');
+  });
+});

--- a/src/actions/testimonials/delete-testimonial.test.ts
+++ b/src/actions/testimonials/delete-testimonial.test.ts
@@ -1,0 +1,121 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import { deleteTestimonial } from './delete-testimonial';
+
+jest.mock('@/actions/notifications/notify-admins', () => ({
+  notifyAdmins: jest.fn().mockResolvedValue(undefined),
+}));
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+const testimonialOwnedByRegular = {
+  id: 'test-1',
+  body: 'A testimonial body for testing.',
+  userId: 'user-regular',
+  featured: false,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+  user: { name: 'Regular' },
+};
+
+const testimonialOwnedByOther = { ...testimonialOwnedByRegular, userId: 'user-other' };
+
+describe('deleteTestimonial', () => {
+  it('throws when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(deleteTestimonial('test-1')).rejects.toThrow('No autorizado');
+    expect(prismaMock.testimonial.delete).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(deleteTestimonial('test-1')).rejects.toThrow('No autorizado');
+    expect(prismaMock.testimonial.delete).not.toHaveBeenCalled();
+  });
+
+  it('throws when the testimonial does not exist', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+    prismaMock.testimonial.findUnique.mockResolvedValue(null);
+
+    await expect(deleteTestimonial('test-1')).rejects.toThrow('Testimonio no encontrado');
+    expect(prismaMock.testimonial.delete).not.toHaveBeenCalled();
+  });
+
+  it('throws when the user is neither the author nor an admin', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+    prismaMock.testimonial.findUnique.mockResolvedValue(testimonialOwnedByOther as any);
+
+    await expect(deleteTestimonial('test-1')).rejects.toThrow(
+      'No tienes permisos para eliminar este testimonio',
+    );
+    expect(prismaMock.testimonial.delete).not.toHaveBeenCalled();
+  });
+
+  it('deletes the testimonial and revalidates the path when user is the author', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+    prismaMock.testimonial.findUnique.mockResolvedValue(testimonialOwnedByRegular as any);
+    prismaMock.testimonial.delete.mockResolvedValue(testimonialOwnedByRegular as any);
+
+    await deleteTestimonial('test-1');
+
+    expect(prismaMock.testimonial.delete).toHaveBeenCalledWith({ where: { id: 'test-1' } });
+    expect(revalidatePath).toHaveBeenCalledWith('/testimonios');
+  });
+
+  it('allows an admin to delete any testimonial', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.testimonial.findUnique.mockResolvedValue(testimonialOwnedByOther as any);
+    prismaMock.testimonial.delete.mockResolvedValue(testimonialOwnedByOther as any);
+
+    await deleteTestimonial('test-1');
+
+    expect(prismaMock.testimonial.delete).toHaveBeenCalledWith({ where: { id: 'test-1' } });
+    expect(revalidatePath).toHaveBeenCalledWith('/testimonios');
+  });
+});

--- a/src/actions/testimonials/fetch-featured-testimonials.test.ts
+++ b/src/actions/testimonials/fetch-featured-testimonials.test.ts
@@ -1,0 +1,40 @@
+import { prismaMock } from '@/test/prisma';
+import { fetchFeaturedTestimonials } from './fetch-featured-testimonials';
+
+const featuredTestimonial = {
+  id: 'test-1',
+  body: 'A featured testimonial body.',
+  userId: 'user-1',
+  featured: true,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+  user: { id: 'user-1', name: 'User One', email: 'user1@pcn.com', image: null },
+};
+
+describe('fetchFeaturedTestimonials', () => {
+  it('returns featured testimonials ordered by creation date', async () => {
+    prismaMock.testimonial.findMany.mockResolvedValue([featuredTestimonial] as any);
+
+    const result = await fetchFeaturedTestimonials();
+
+    expect(result).toEqual([featuredTestimonial]);
+    expect(prismaMock.testimonial.findMany).toHaveBeenCalledWith({
+      where: { featured: true },
+      orderBy: { createdAt: 'desc' },
+      take: 3,
+      include: {
+        user: {
+          select: { id: true, name: true, email: true, image: true },
+        },
+      },
+    });
+  });
+
+  it('returns an empty array when there are no featured testimonials', async () => {
+    prismaMock.testimonial.findMany.mockResolvedValue([]);
+
+    const result = await fetchFeaturedTestimonials();
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/actions/testimonials/fetch-testimonial.test.ts
+++ b/src/actions/testimonials/fetch-testimonial.test.ts
@@ -1,0 +1,38 @@
+import { prismaMock } from '@/test/prisma';
+import { fetchTestimonial } from './fetch-testimonial';
+
+const testimonialWithUser = {
+  id: 'test-1',
+  body: 'A testimonial body.',
+  userId: 'user-1',
+  featured: false,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+  user: { id: 'user-1', name: 'User One', email: 'user1@pcn.com', image: null },
+};
+
+describe('fetchTestimonial', () => {
+  it('returns the testimonial when it exists', async () => {
+    prismaMock.testimonial.findUnique.mockResolvedValue(testimonialWithUser as any);
+
+    const result = await fetchTestimonial('test-1');
+
+    expect(result).toEqual(testimonialWithUser);
+    expect(prismaMock.testimonial.findUnique).toHaveBeenCalledWith({
+      where: { id: 'test-1' },
+      include: {
+        user: {
+          select: { id: true, name: true, email: true, image: true },
+        },
+      },
+    });
+  });
+
+  it('returns null when the testimonial does not exist', async () => {
+    prismaMock.testimonial.findUnique.mockResolvedValue(null);
+
+    const result = await fetchTestimonial('nonexistent');
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/actions/testimonials/fetch-testimonials.test.ts
+++ b/src/actions/testimonials/fetch-testimonials.test.ts
@@ -1,0 +1,38 @@
+import { prismaMock } from '@/test/prisma';
+import { fetchTestimonials } from './fetch-testimonials';
+
+const testimonialWithUser = {
+  id: 'test-1',
+  body: 'A testimonial body.',
+  userId: 'user-1',
+  featured: false,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+  user: { id: 'user-1', name: 'User One', email: 'user1@pcn.com', image: null },
+};
+
+describe('fetchTestimonials', () => {
+  it('returns the list of testimonials ordered by creation date', async () => {
+    prismaMock.testimonial.findMany.mockResolvedValue([testimonialWithUser] as any);
+
+    const result = await fetchTestimonials();
+
+    expect(result).toEqual([testimonialWithUser]);
+    expect(prismaMock.testimonial.findMany).toHaveBeenCalledWith({
+      orderBy: { createdAt: 'desc' },
+      include: {
+        user: {
+          select: { id: true, name: true, email: true, image: true },
+        },
+      },
+    });
+  });
+
+  it('returns an empty array when there are no testimonials', async () => {
+    prismaMock.testimonial.findMany.mockResolvedValue([]);
+
+    const result = await fetchTestimonials();
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/actions/testimonials/toggle-featured.test.ts
+++ b/src/actions/testimonials/toggle-featured.test.ts
@@ -1,0 +1,131 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import { toggleFeatured } from './toggle-featured';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+const unfeaturedTestimonial = {
+  id: 'test-1',
+  body: 'A testimonial body for testing.',
+  userId: 'user-regular',
+  featured: false,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const featuredTestimonial = { ...unfeaturedTestimonial, featured: true };
+
+describe('toggleFeatured', () => {
+  it('throws when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(toggleFeatured('test-1')).rejects.toThrow('No autorizado');
+    expect(prismaMock.testimonial.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session belongs to a non-admin user', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+
+    await expect(toggleFeatured('test-1')).rejects.toThrow(
+      'Solo los administradores pueden marcar testimonios como destacados',
+    );
+    expect(prismaMock.testimonial.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(toggleFeatured('test-1')).rejects.toThrow(
+      'Solo los administradores pueden marcar testimonios como destacados',
+    );
+    expect(prismaMock.testimonial.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the testimonial does not exist', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.testimonial.findUnique.mockResolvedValue(null);
+
+    await expect(toggleFeatured('test-1')).rejects.toThrow('Testimonio no encontrado');
+    expect(prismaMock.testimonial.update).not.toHaveBeenCalled();
+  });
+
+  it('sets featured to true when it was false and revalidates both paths', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.testimonial.findUnique.mockResolvedValue(unfeaturedTestimonial as any);
+    prismaMock.testimonial.update.mockResolvedValue({
+      ...unfeaturedTestimonial,
+      featured: true,
+    } as any);
+
+    await toggleFeatured('test-1');
+
+    expect(prismaMock.testimonial.update).toHaveBeenCalledWith({
+      where: { id: 'test-1' },
+      data: { featured: true },
+    });
+    expect(revalidatePath).toHaveBeenCalledWith('/testimonios');
+    expect(revalidatePath).toHaveBeenCalledWith('/home');
+  });
+
+  it('sets featured to false when it was true and revalidates both paths', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.testimonial.findUnique.mockResolvedValue(featuredTestimonial as any);
+    prismaMock.testimonial.update.mockResolvedValue({
+      ...featuredTestimonial,
+      featured: false,
+    } as any);
+
+    await toggleFeatured('test-1');
+
+    expect(prismaMock.testimonial.update).toHaveBeenCalledWith({
+      where: { id: 'test-1' },
+      data: { featured: false },
+    });
+    expect(revalidatePath).toHaveBeenCalledWith('/testimonios');
+    expect(revalidatePath).toHaveBeenCalledWith('/home');
+  });
+});

--- a/src/actions/testimonials/update-testimonial.test.ts
+++ b/src/actions/testimonials/update-testimonial.test.ts
@@ -1,0 +1,136 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { revalidatePath } from 'next/cache';
+import { updateTestimonial } from './update-testimonial';
+
+jest.mock('@/actions/notifications/notify-admins', () => ({
+  notifyAdmins: jest.fn().mockResolvedValue(undefined),
+}));
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+const testimonialOwnedByRegular = {
+  id: 'test-1',
+  body: 'Original testimonial body here.',
+  userId: 'user-regular',
+  featured: false,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+  user: { name: 'Regular' },
+};
+
+const testimonialOwnedByOther = { ...testimonialOwnedByRegular, userId: 'user-other' };
+
+const validData = { body: 'Updated testimonial body content.' };
+
+describe('updateTestimonial', () => {
+  it('throws when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(updateTestimonial('test-1', validData)).rejects.toThrow('No autorizado');
+    expect(prismaMock.testimonial.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(updateTestimonial('test-1', validData)).rejects.toThrow('No autorizado');
+    expect(prismaMock.testimonial.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the testimonial does not exist', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+    prismaMock.testimonial.findUnique.mockResolvedValue(null);
+
+    await expect(updateTestimonial('test-1', validData)).rejects.toThrow(
+      'Testimonio no encontrado',
+    );
+    expect(prismaMock.testimonial.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the user is neither the author nor an admin', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+    prismaMock.testimonial.findUnique.mockResolvedValue(testimonialOwnedByOther as any);
+
+    await expect(updateTestimonial('test-1', validData)).rejects.toThrow(
+      'No tienes permisos para editar este testimonio',
+    );
+    expect(prismaMock.testimonial.update).not.toHaveBeenCalled();
+  });
+
+  it('updates the testimonial and revalidates the path when user is the author', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+    prismaMock.testimonial.findUnique.mockResolvedValue(testimonialOwnedByRegular as any);
+    prismaMock.testimonial.update.mockResolvedValue({
+      ...testimonialOwnedByRegular,
+      body: validData.body,
+    } as any);
+
+    await updateTestimonial('test-1', validData);
+
+    expect(prismaMock.testimonial.update).toHaveBeenCalledWith({
+      where: { id: 'test-1' },
+      data: { body: validData.body },
+    });
+    expect(revalidatePath).toHaveBeenCalledWith('/testimonios');
+  });
+
+  it('updates the testimonial without notifying when an admin edits', async () => {
+    const { notifyAdmins } = jest.requireMock('@/actions/notifications/notify-admins');
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.testimonial.findUnique.mockResolvedValue(testimonialOwnedByRegular as any);
+    prismaMock.testimonial.update.mockResolvedValue({
+      ...testimonialOwnedByRegular,
+      body: validData.body,
+    } as any);
+
+    await updateTestimonial('test-1', validData);
+
+    expect(prismaMock.testimonial.update).toHaveBeenCalled();
+    expect(notifyAdmins).not.toHaveBeenCalled();
+    expect(revalidatePath).toHaveBeenCalledWith('/testimonios');
+  });
+});

--- a/src/actions/update-profile.test.ts
+++ b/src/actions/update-profile.test.ts
@@ -1,0 +1,99 @@
+import { revalidatePath } from 'next/cache';
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import type { ProfileFormData } from '@/schemas/profile-schema';
+import { updateProfile } from './update-profile';
+
+const validProfileData: ProfileFormData = {
+  name: 'Test User',
+  email: 'test@example.com',
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  programmingLanguages: [],
+};
+
+const validProfileDataWithLanguages: ProfileFormData = {
+  ...validProfileData,
+  programmingLanguages: [
+    { languageId: 'typescript', color: '#3178c6', logo: 'ts-logo.svg' },
+    { languageId: 'python', color: '#3572A5', logo: 'py-logo.svg' },
+  ],
+};
+
+const baseSession = {
+  id: 'session-1',
+  userId: 'user-1',
+  expires: new Date('2027-01-01'),
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+describe('updateProfile', () => {
+  it('redirects to / when there is no sessionId cookie', async () => {
+    mockCookies(); // no sessionId
+
+    await expect(updateProfile(validProfileData)).rejects.toThrow('NEXT_REDIRECT:/');
+
+    expect(prismaMock.session.findUnique).not.toHaveBeenCalled();
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
+  });
+
+  it('redirects to / when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'ghost-session' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(updateProfile(validProfileData)).rejects.toThrow('NEXT_REDIRECT:/');
+
+    expect(prismaMock.user.update).not.toHaveBeenCalled();
+  });
+
+  it('updates the user, deletes old languages, and revalidates the path on success', async () => {
+    mockCookies({ sessionId: 'session-1' });
+    prismaMock.session.findUnique.mockResolvedValue(baseSession as any);
+    prismaMock.user.update.mockResolvedValue({} as any);
+    prismaMock.userLanguage.deleteMany.mockResolvedValue({ count: 0 } as any);
+
+    await updateProfile(validProfileData);
+
+    expect(prismaMock.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'user-1' },
+      }),
+    );
+    expect(prismaMock.userLanguage.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: 'user-1' } }),
+    );
+    expect(prismaMock.userLanguage.createMany).not.toHaveBeenCalled();
+    expect(revalidatePath).toHaveBeenCalledWith('/perfil');
+  });
+
+  it('creates new language entries when programmingLanguages are provided', async () => {
+    mockCookies({ sessionId: 'session-1' });
+    prismaMock.session.findUnique.mockResolvedValue(baseSession as any);
+    prismaMock.user.update.mockResolvedValue({} as any);
+    prismaMock.userLanguage.deleteMany.mockResolvedValue({ count: 0 } as any);
+    prismaMock.userLanguage.createMany.mockResolvedValue({ count: 2 } as any);
+
+    await updateProfile(validProfileDataWithLanguages);
+
+    expect(prismaMock.userLanguage.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([
+          expect.objectContaining({ userId: 'user-1', language: 'typescript' }),
+          expect.objectContaining({ userId: 'user-1', language: 'python' }),
+        ]),
+      }),
+    );
+    expect(revalidatePath).toHaveBeenCalledWith('/perfil');
+  });
+});

--- a/src/actions/upload/get-presigned-url-public.test.ts
+++ b/src/actions/upload/get-presigned-url-public.test.ts
@@ -1,0 +1,49 @@
+import { getPresignedUrlPublic } from './get-presigned-url-public';
+import { getPresignedUploadUrl } from '@/lib/s3';
+
+jest.mock('@/lib/s3', () => ({
+  getPresignedUploadUrl: jest.fn().mockResolvedValue({
+    uploadUrl: 'https://s3.example.com/presigned',
+    fileUrl: 'https://s3.example.com/file',
+  }),
+}));
+
+describe('getPresignedUrlPublic', () => {
+  it('throws when the content type is not allowed', async () => {
+    await expect(
+      getPresignedUrlPublic({ fileName: 'doc.pdf', contentType: 'application/pdf' }),
+    ).rejects.toThrow('Tipo de archivo no permitido');
+    expect(getPresignedUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it('returns uploadUrl and fileUrl on a valid request', async () => {
+    const result = await getPresignedUrlPublic({
+      fileName: 'avatar.jpg',
+      contentType: 'image/jpeg',
+    });
+
+    expect(result).toEqual({
+      uploadUrl: 'https://s3.example.com/presigned',
+      fileUrl: 'https://s3.example.com/file',
+    });
+  });
+
+  it('always uploads to the registration-profiles folder regardless of input', async () => {
+    await getPresignedUrlPublic({ fileName: 'photo.png', contentType: 'image/png' });
+
+    expect(getPresignedUploadUrl).toHaveBeenCalledWith(
+      'photo.png',
+      'image/png',
+      'registration-profiles',
+    );
+  });
+
+  it('accepts all allowed image types', async () => {
+    const allowedTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+
+    for (const contentType of allowedTypes) {
+      (getPresignedUploadUrl as jest.Mock).mockClear();
+      await expect(getPresignedUrlPublic({ fileName: 'img', contentType })).resolves.toBeDefined();
+    }
+  });
+});

--- a/src/actions/upload/get-presigned-url.test.ts
+++ b/src/actions/upload/get-presigned-url.test.ts
@@ -1,0 +1,132 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { getPresignedUrl } from './get-presigned-url';
+import { getPresignedUploadUrl } from '@/lib/s3';
+
+jest.mock('@/lib/s3', () => ({
+  getPresignedUploadUrl: jest.fn().mockResolvedValue({
+    uploadUrl: 'https://s3.example.com/presigned',
+    fileUrl: 'https://s3.example.com/file',
+  }),
+}));
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+describe('getPresignedUrl', () => {
+  it('throws when there is no session cookie', async () => {
+    mockCookies();
+
+    await expect(
+      getPresignedUrl({ fileName: 'img.jpg', contentType: 'image/jpeg' }),
+    ).rejects.toThrow('No autorizado');
+    expect(prismaMock.session.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('throws when the session is not found in the database', async () => {
+    mockCookies({ sessionId: 'session-xxx' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(
+      getPresignedUrl({ fileName: 'img.jpg', contentType: 'image/jpeg' }),
+    ).rejects.toThrow('No autorizado');
+  });
+
+  it('throws when a regular user tries to upload to a non-profile folder', async () => {
+    mockCookies({ sessionId: regularSession.id });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+
+    await expect(
+      getPresignedUrl({ fileName: 'img.jpg', contentType: 'image/jpeg', folder: 'events' }),
+    ).rejects.toThrow('No tienes permisos para subir archivos');
+    expect(getPresignedUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it('allows a regular user to upload to the profiles folder', async () => {
+    mockCookies({ sessionId: regularSession.id });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+
+    const result = await getPresignedUrl({
+      fileName: 'avatar.jpg',
+      contentType: 'image/jpeg',
+      folder: 'profiles',
+    });
+
+    expect(result).toEqual({
+      uploadUrl: 'https://s3.example.com/presigned',
+      fileUrl: 'https://s3.example.com/file',
+    });
+    expect(getPresignedUploadUrl).toHaveBeenCalledWith('avatar.jpg', 'image/jpeg', 'profiles');
+  });
+
+  it('allows an admin user to upload to any folder', async () => {
+    mockCookies({ sessionId: adminSession.id });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+
+    const result = await getPresignedUrl({
+      fileName: 'banner.png',
+      contentType: 'image/png',
+      folder: 'events',
+    });
+
+    expect(result).toEqual({
+      uploadUrl: 'https://s3.example.com/presigned',
+      fileUrl: 'https://s3.example.com/file',
+    });
+    expect(getPresignedUploadUrl).toHaveBeenCalledWith('banner.png', 'image/png', 'events');
+  });
+
+  it('throws when the content type is not allowed', async () => {
+    mockCookies({ sessionId: adminSession.id });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+
+    await expect(
+      getPresignedUrl({ fileName: 'doc.pdf', contentType: 'application/pdf' }),
+    ).rejects.toThrow('Tipo de archivo no permitido');
+    expect(getPresignedUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it('uses the default folder "events" when no folder is specified', async () => {
+    mockCookies({ sessionId: adminSession.id });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+
+    await getPresignedUrl({ fileName: 'img.webp', contentType: 'image/webp' });
+
+    expect(getPresignedUploadUrl).toHaveBeenCalledWith('img.webp', 'image/webp', 'events');
+  });
+});

--- a/src/actions/users/get-users.test.ts
+++ b/src/actions/users/get-users.test.ts
@@ -1,0 +1,92 @@
+import { prismaMock } from '@/test/prisma';
+import { getUsers } from './get-users';
+
+const stubUserWithoutPassword = {
+  id: 'user-1',
+  name: 'Test User',
+  email: 'test@pcn.com',
+  emailVerified: true,
+  phoneNumber: null,
+  role: 'REGULAR' as const,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+  languages: [{ language: 'TypeScript', color: '#3178c6', logo: 'ts.svg' }],
+};
+
+const secondUser = {
+  ...stubUserWithoutPassword,
+  id: 'user-2',
+  name: 'Second User',
+  email: 'second@pcn.com',
+  createdAt: new Date('2024-12-01'),
+  updatedAt: new Date('2024-12-01'),
+  languages: [],
+};
+
+describe('getUsers', () => {
+  it('returns a list of users without the password field', async () => {
+    prismaMock.user.findMany.mockResolvedValue([stubUserWithoutPassword] as any);
+
+    const result = await getUsers();
+
+    expect(prismaMock.user.findMany).toHaveBeenCalledWith({
+      select: expect.objectContaining({
+        id: true,
+        name: true,
+        email: true,
+        emailVerified: true,
+        role: true,
+        languages: expect.objectContaining({
+          select: { language: true, color: true, logo: true },
+        }),
+      }),
+      orderBy: { createdAt: 'desc' },
+    });
+    // password must NOT be in the select
+    expect(prismaMock.user.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.not.objectContaining({ password: expect.anything() }),
+      }),
+    );
+    expect(result).toEqual([stubUserWithoutPassword]);
+  });
+
+  it('returns multiple users ordered by createdAt descending', async () => {
+    prismaMock.user.findMany.mockResolvedValue([stubUserWithoutPassword, secondUser] as any);
+
+    const result = await getUsers();
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('user-1');
+    expect(result[1].id).toBe('user-2');
+  });
+
+  it('returns an empty array when there are no users', async () => {
+    prismaMock.user.findMany.mockResolvedValue([]);
+
+    const result = await getUsers();
+
+    expect(result).toEqual([]);
+  });
+
+  it('includes languages for each user', async () => {
+    prismaMock.user.findMany.mockResolvedValue([stubUserWithoutPassword] as any);
+
+    const result = await getUsers();
+
+    expect(result[0].languages).toEqual([
+      { language: 'TypeScript', color: '#3178c6', logo: 'ts.svg' },
+    ]);
+  });
+});

--- a/src/actions/users/search-users-for-speaker.test.ts
+++ b/src/actions/users/search-users-for-speaker.test.ts
@@ -1,0 +1,199 @@
+import { prismaMock } from '@/test/prisma';
+import { mockCookies } from '@/test/cookies';
+import { searchUsersForSpeaker, getUserForSpeaker } from './search-users-for-speaker';
+
+const adminUser = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  password: 'hash',
+  emailVerified: true,
+  role: 'ADMIN' as const,
+  phoneNumber: null,
+  image: null,
+  countryOfOrigin: null,
+  province: null,
+  xAccountUrl: null,
+  linkedinUrl: null,
+  gitHubUrl: null,
+  slogan: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const adminSession = {
+  id: 'session-admin',
+  userId: 'user-admin',
+  expires: new Date('2027-01-01'),
+  user: adminUser,
+  createdAt: new Date('2025-01-01'),
+  updatedAt: new Date('2025-01-01'),
+};
+
+const regularUser = { ...adminUser, id: 'user-regular', role: 'REGULAR' as const };
+const regularSession = {
+  ...adminSession,
+  id: 'session-regular',
+  userId: 'user-regular',
+  user: regularUser,
+};
+
+const speakerOption = {
+  id: 'user-admin',
+  name: 'Admin',
+  email: 'admin@pcn.com',
+  image: null,
+  phoneNumber: null,
+  jobTitle: null,
+  enterprise: null,
+  career: null,
+  studyPlace: null,
+};
+
+const speakerSelect = {
+  id: true,
+  name: true,
+  email: true,
+  image: true,
+  phoneNumber: true,
+  jobTitle: true,
+  enterprise: true,
+  career: true,
+  studyPlace: true,
+};
+
+describe('searchUsersForSpeaker', () => {
+  it('throws "No autorizado" when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(searchUsersForSpeaker('test')).rejects.toThrow('No autorizado');
+    expect(prismaMock.user.findMany).not.toHaveBeenCalled();
+  });
+
+  it('throws "No autorizado" when the session is not found', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(searchUsersForSpeaker('test')).rejects.toThrow('No autorizado');
+    expect(prismaMock.user.findMany).not.toHaveBeenCalled();
+  });
+
+  it('throws "No autorizado" for a non-ADMIN user', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+
+    await expect(searchUsersForSpeaker('test')).rejects.toThrow('No autorizado');
+    expect(prismaMock.user.findMany).not.toHaveBeenCalled();
+  });
+
+  it('queries by name and email when a search term is provided', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.user.findMany.mockResolvedValue([speakerOption] as any);
+
+    const result = await searchUsersForSpeaker('admin');
+
+    expect(prismaMock.user.findMany).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { name: { contains: 'admin', mode: 'insensitive' } },
+          { email: { contains: 'admin', mode: 'insensitive' } },
+        ],
+      },
+      select: speakerSelect,
+      orderBy: { name: 'asc' },
+      take: 20,
+    });
+    expect(result).toEqual([speakerOption]);
+  });
+
+  it('passes undefined where clause when the query is an empty string', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.user.findMany.mockResolvedValue([speakerOption] as any);
+
+    await searchUsersForSpeaker('');
+
+    expect(prismaMock.user.findMany).toHaveBeenCalledWith({
+      where: undefined,
+      select: speakerSelect,
+      orderBy: { name: 'asc' },
+      take: 20,
+    });
+  });
+
+  it('passes undefined where clause when the query is whitespace only', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.user.findMany.mockResolvedValue([]) as any;
+
+    await searchUsersForSpeaker('   ');
+
+    expect(prismaMock.user.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: undefined }),
+    );
+  });
+
+  it('respects a custom limit', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.user.findMany.mockResolvedValue([]);
+
+    await searchUsersForSpeaker('test', 5);
+
+    expect(prismaMock.user.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 5 }));
+  });
+});
+
+describe('getUserForSpeaker', () => {
+  it('throws "No autorizado" when there is no sessionId cookie', async () => {
+    mockCookies();
+
+    await expect(getUserForSpeaker('user-admin')).rejects.toThrow('No autorizado');
+    expect(prismaMock.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('throws "No autorizado" when the session is not found', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(null);
+
+    await expect(getUserForSpeaker('user-admin')).rejects.toThrow('No autorizado');
+    expect(prismaMock.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('throws "No autorizado" for a non-ADMIN user', async () => {
+    mockCookies({ sessionId: 'session-regular' });
+    prismaMock.session.findUnique.mockResolvedValue(regularSession as any);
+
+    await expect(getUserForSpeaker('user-admin')).rejects.toThrow('No autorizado');
+    expect(prismaMock.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('returns the user for a given id when called by an ADMIN', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.user.findUnique.mockResolvedValue(speakerOption as any);
+
+    const result = await getUserForSpeaker('user-admin');
+
+    expect(prismaMock.user.findUnique).toHaveBeenCalledWith({
+      where: { id: 'user-admin' },
+      select: speakerSelect,
+    });
+    expect(result).toEqual(speakerOption);
+  });
+
+  it('returns null when the user does not exist', async () => {
+    mockCookies({ sessionId: 'session-admin' });
+    prismaMock.session.findUnique.mockResolvedValue(adminSession as any);
+    prismaMock.user.findUnique.mockResolvedValue(null);
+
+    const result = await getUserForSpeaker('non-existent');
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/test/headers.ts
+++ b/src/test/headers.ts
@@ -1,0 +1,22 @@
+import { headers } from 'next/headers';
+
+export interface MockHeaderStore {
+  get: jest.Mock;
+  has: jest.Mock;
+}
+
+/**
+ * Configure the globally-mocked `headers()` from `next/headers` to return
+ * a header store pre-populated with the given key/value pairs.
+ *
+ * Usage:
+ *   mockHeaders({ 'x-forwarded-for': '1.2.3.4', 'user-agent': 'Jest' });
+ */
+export function mockHeaders(values: Record<string, string | undefined> = {}): MockHeaderStore {
+  const store: MockHeaderStore = {
+    get: jest.fn((name: string) => values[name.toLowerCase()] ?? null),
+    has: jest.fn((name: string) => name.toLowerCase() in values),
+  };
+  (headers as jest.Mock).mockResolvedValue(store);
+  return store;
+}


### PR DESCRIPTION
## Summary

- Add 315 tests across **65 new co-located `*.test.ts` files**, covering every previously untested Next.js server action under `src/actions/`
- Extend `jest.setup.ts` to also mock `headers()` from `next/headers` (needed by logs/errors/analytics actions)
- Add `src/test/headers.ts` helper — mirrors the existing `cookies.ts` helper for stubbing request headers per test

## Coverage by domain

| Domain | Files |
|---|---|
| `auth/` | sign-out, send-verification-code, verify-email-code, request-password-reset, verify-reset-code, complete-password-reset |
| `events/` | update, delete, fetch-events, fetch-event, fetch-event-for-edit, fetch-upcoming, fetch-recently-added, check-capacity, register, cancel-registration, delete-registration, get-registrations |
| `talks/` | create, update, delete, create-from-proposal, fetch-talks, fetch-public, fetch-events-for-select |
| `talk-proposals/` | create, update-status, delete, fetch |
| `advises/` | create, edit, delete, like (toggle), get-best |
| `testimonials/` | create, update, delete, toggle-featured, fetch-all, fetch-one, fetch-featured |
| `announcements/` | create, update, delete, get-announcements, get-event-announcements, get-events-for-select |
| `comments/` | create-comment (with Zod validation cases) |
| `notifications/` | notify-admins, fetch, get-unread-count, mark-as-read, mark-all-as-read |
| `users/` | get-users, search-users-for-speaker |
| `upload/` | get-presigned-url, get-presigned-url-public |
| `logs/` | fetch-logs + getLogStats, log-client |
| `errors/` | log-error + logClientError, fetch-errors + getErrorStats, mark-as-resolved |
| `analytics/` | track-page-visit, fetch-page-visits + getPageVisitStats |
| `root/` | update-profile |

## Test plan

- [x] `pnpm test` — 315 tests, 68 suites, all green (0.8s, node env, no real DB)
- [x] ESLint — no warnings
- [x] Prettier — all files formatted
- [x] `next build` — production build succeeds