### PR TITLE
feat(sidebar): move Herramientas to top-level nav after Especialidades

### DIFF
--- a/src/components/ui/app-sidebar.tsx
+++ b/src/components/ui/app-sidebar.tsx
@@ -23,6 +23,7 @@ import {
   Send,
   Share2,
   Users,
+  Wrench,
   Youtube,
 } from 'lucide-react';
 import { NavMain } from '@/components/ui/nav-main';
@@ -110,11 +111,11 @@ const getRecursosItems = () => [
   { title: 'Cursos', url: '/cursos', icon: GraduationCap },
   { title: 'Lectura', url: '/lectura', icon: BookOpen },
   { title: 'Especialidades', url: '/especialidades', icon: Layers },
+  { title: 'Herramientas', url: '/herramientas', icon: Wrench },
   {
     title: 'Más recursos',
     icon: Library,
     items: [
-      { title: 'Herramientas', url: '/herramientas' },
       { title: 'Influencers', url: '/influencers' },
       { title: 'Música', url: '/music' },
       { title: 'Series y películas', url: '/series-y-peliculas' },


### PR DESCRIPTION
## Summary

- Promotes **Herramientas** from the collapsible **Más recursos** dropdown to a standalone top-level item in the sidebar's Recursos section
- Placed directly after **Especialidades** for one-click access
- Added `Wrench` icon from `lucide-react` (required for top-level items)

## Test plan

- [ ] Open the sidebar and verify **Herramientas** appears as a top-level item (with a wrench icon) right after **Especialidades** under Recursos
- [ ] Confirm clicking it navigates to `/herramientas`
- [ ] Expand **Más recursos** and confirm **Herramientas** is no longer listed there