### PR TITLE
fix(especialidades): left-align page header to match other pages

### DIFF
--- a/src/app/(platform)/especialidades/page.tsx
+++ b/src/app/(platform)/especialidades/page.tsx
@@ -81,9 +81,9 @@ const SpecialtiesPage = () => (
     </header>
     <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
       <div className="mt-4">
-        <div className="mb-12 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
-          <div className="flex flex-col items-center gap-4">
-            <Heading2 className="m-0 flex items-center justify-center gap-3">
+        <div className="mb-4 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+          <div className="flex flex-col gap-4">
+            <Heading2 className="m-0 flex items-center gap-3">
               <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-pcnPurple/30 bg-pcnPurple/10 dark:border-pcnGreen/50 dark:bg-pcnGreen/10 dark:shadow-[0_0_10px_rgba(4,244,190,0.4)]">
                 <Code className="h-5 w-5 text-pcnPurple dark:text-pcnGreen dark:drop-shadow-[0_0_8px_rgba(4,244,190,0.8)]" />
               </div>
@@ -91,7 +91,7 @@ const SpecialtiesPage = () => (
                 Especialidades
               </span>
             </Heading2>
-            <p className="max-w-3xl text-center text-muted-foreground">
+            <p className="max-w-3xl text-muted-foreground">
               El mundo del software es vasto y diverso. Acá te presentamos las principales
               especialidades en las que podés enfocar tu carrera profesional.
             </p>


### PR DESCRIPTION
## Summary

- Removes `items-center` from the header wrapper so the title and subtitle no longer center-align horizontally
- Removes `justify-center` from `Heading2` so the icon + title text aligns to the left
- Removes `text-center` from the subtitle paragraph
- Changes `mb-12` → `mb-4` to match the bottom margin used on other pages

Makes the `/especialidades` header consistent with `/consejos`, `/cursos`, `/eventos`, and the rest of the platform pages.

## Test plan

- [ ] Visit `/especialidades` and confirm the "Especialidades" title is left-aligned
- [ ] Confirm the subtitle paragraph is also left-aligned
- [ ] Confirm the icon badge, glow effects, and dark-mode styling are unchanged
- [ ] Compare visually with `/consejos` or `/cursos` to verify consistency