### PR TITLE
feat(proyectos): add community software projects showcase page

### DIFF
--- a/prisma/migrations/20260618164504_add_projects/migration.sql
+++ b/prisma/migrations/20260618164504_add_projects/migration.sql
@@ -1,0 +1,42 @@
+-- CreateTable
+CREATE TABLE "Project" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "logoUrl" TEXT NOT NULL,
+    "techStack" TEXT[],
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Project_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ProjectMember" (
+    "id" TEXT NOT NULL,
+    "projectId" TEXT NOT NULL,
+    "userId" TEXT,
+    "memberName" TEXT NOT NULL,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProjectMember_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ProjectMember_projectId_idx" ON "ProjectMember"("projectId");
+
+-- CreateIndex
+CREATE INDEX "ProjectMember_userId_idx" ON "ProjectMember"("userId");
+
+-- CreateIndex
+CREATE INDEX "ProjectMember_projectId_order_idx" ON "ProjectMember"("projectId", "order");
+
+-- AddForeignKey
+ALTER TABLE "ProjectMember" ADD CONSTRAINT "ProjectMember_projectId_fkey" FOREIGN KEY ("projectId") REFERENCES "Project"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ProjectMember" ADD CONSTRAINT "ProjectMember_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,6 +48,7 @@ model User {
   resolvedErrors  ErrorLog[] @relation("ErrorLogResolver")
   appLogs         AppLog[]
   announcements   Announcement[]
+  projectMemberships ProjectMember[] @relation("UserProjectMembers")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -447,4 +448,37 @@ model TalkSpeaker {
   @@index([talkId])
   @@index([userId])
   @@index([talkId, order])
+}
+
+model Project {
+  id          String   @id @default(cuid())
+  title       String
+  description String
+  url         String
+  logoUrl     String
+  techStack   String[]
+  order       Int      @default(0)
+
+  members ProjectMember[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+model ProjectMember {
+  id         String  @id @default(cuid())
+  projectId  String
+  userId     String?
+  memberName String
+  order      Int     @default(0)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  user    User?   @relation("UserProjectMembers", fields: [userId], references: [id], onDelete: SetNull)
+
+  @@index([projectId])
+  @@index([userId])
+  @@index([projectId, order])
 }

--- a/src/actions/projects/create-project.ts
+++ b/src/actions/projects/create-project.ts
@@ -1,0 +1,51 @@
+'use server';
+
+import prisma from '@/lib/prisma';
+import { revalidatePath } from 'next/cache';
+import { cookies } from 'next/headers';
+import { projectSchema, ProjectFormData } from '@/schemas/project-schema';
+
+export const createProject = async (data: ProjectFormData) => {
+  const sessionId = (await cookies()).get('sessionId')?.value;
+  if (!sessionId) {
+    throw new Error('Debes estar autenticado');
+  }
+
+  const session = await prisma.session.findUnique({
+    where: { id: sessionId },
+    include: { user: true },
+  });
+
+  if (!session || session.user.role !== 'ADMIN') {
+    throw new Error('No tenés permisos para realizar esta acción');
+  }
+
+  const parsed = projectSchema.safeParse(data);
+  if (!parsed.success) {
+    throw new Error(parsed.error.errors[0]?.message ?? 'Datos inválidos');
+  }
+
+  const projectData = parsed.data;
+
+  const project = await prisma.project.create({
+    data: {
+      title: projectData.title,
+      description: projectData.description,
+      url: projectData.url,
+      logoUrl: projectData.logoUrl ?? '',
+      techStack: projectData.techStack,
+      order: projectData.order,
+      members: {
+        create: projectData.members.map((m, idx) => ({
+          userId: m.userId ?? null,
+          memberName: m.memberName,
+          order: idx,
+        })),
+      },
+    },
+  });
+
+  revalidatePath('/proyectos');
+
+  return { success: true, projectId: project.id };
+};

--- a/src/actions/projects/delete-project.ts
+++ b/src/actions/projects/delete-project.ts
@@ -1,0 +1,32 @@
+'use server';
+
+import prisma from '@/lib/prisma';
+import { revalidatePath } from 'next/cache';
+import { cookies } from 'next/headers';
+
+export const deleteProject = async (id: string) => {
+  const sessionId = (await cookies()).get('sessionId')?.value;
+  if (!sessionId) {
+    throw new Error('Debes estar autenticado');
+  }
+
+  const session = await prisma.session.findUnique({
+    where: { id: sessionId },
+    include: { user: true },
+  });
+
+  if (!session || session.user.role !== 'ADMIN') {
+    throw new Error('No tenés permisos para realizar esta acción');
+  }
+
+  const project = await prisma.project.findUnique({ where: { id } });
+  if (!project) {
+    throw new Error('Proyecto no encontrado');
+  }
+
+  await prisma.project.delete({ where: { id } });
+
+  revalidatePath('/proyectos');
+
+  return { success: true };
+};

--- a/src/actions/projects/fetch-public-projects.ts
+++ b/src/actions/projects/fetch-public-projects.ts
@@ -1,0 +1,15 @@
+'use server';
+
+import prisma from '@/lib/prisma';
+
+export const fetchPublicProjects = async () => {
+  return prisma.project.findMany({
+    include: {
+      members: {
+        include: { user: { select: { id: true, name: true, image: true } } },
+        orderBy: { order: 'asc' },
+      },
+    },
+    orderBy: [{ order: 'asc' }, { createdAt: 'desc' }],
+  });
+};

--- a/src/actions/projects/update-project.ts
+++ b/src/actions/projects/update-project.ts
@@ -1,0 +1,61 @@
+'use server';
+
+import prisma from '@/lib/prisma';
+import { revalidatePath } from 'next/cache';
+import { cookies } from 'next/headers';
+import { projectSchema, ProjectFormData } from '@/schemas/project-schema';
+
+export const updateProject = async (id: string, data: ProjectFormData) => {
+  const sessionId = (await cookies()).get('sessionId')?.value;
+  if (!sessionId) {
+    throw new Error('Debes estar autenticado');
+  }
+
+  const session = await prisma.session.findUnique({
+    where: { id: sessionId },
+    include: { user: true },
+  });
+
+  if (!session || session.user.role !== 'ADMIN') {
+    throw new Error('No tenés permisos para realizar esta acción');
+  }
+
+  const parsed = projectSchema.safeParse(data);
+  if (!parsed.success) {
+    throw new Error(parsed.error.errors[0]?.message ?? 'Datos inválidos');
+  }
+
+  const projectData = parsed.data;
+
+  const existing = await prisma.project.findUnique({ where: { id } });
+  if (!existing) {
+    throw new Error('Proyecto no encontrado');
+  }
+
+  await prisma.$transaction([
+    prisma.project.update({
+      where: { id },
+      data: {
+        title: projectData.title,
+        description: projectData.description,
+        url: projectData.url,
+        logoUrl: projectData.logoUrl ?? existing.logoUrl,
+        techStack: projectData.techStack,
+        order: projectData.order,
+      },
+    }),
+    prisma.projectMember.deleteMany({ where: { projectId: id } }),
+    prisma.projectMember.createMany({
+      data: projectData.members.map((m, idx) => ({
+        projectId: id,
+        userId: m.userId ?? null,
+        memberName: m.memberName,
+        order: idx,
+      })),
+    }),
+  ]);
+
+  revalidatePath('/proyectos');
+
+  return { success: true };
+};

--- a/src/app/(platform)/proyectos/page.tsx
+++ b/src/app/(platform)/proyectos/page.tsx
@@ -1,0 +1,79 @@
+import type { Metadata } from 'next';
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+import { Separator } from '@/components/ui/separator';
+import { SidebarTrigger } from '@/components/ui/sidebar';
+import { cookies } from 'next/headers';
+import prisma from '@/lib/prisma';
+import { fetchPublicProjects } from '@/actions/projects/fetch-public-projects';
+import { ProyectosAdminWrapper } from '@/components/projects/proyectos-admin-wrapper';
+
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://programaconnosotros.com';
+
+export const metadata: Metadata = {
+  title: 'Proyectos',
+  description:
+    'Explorá los proyectos de software creados por miembros de la comunidad. Conocé las tecnologías utilizadas y las personas detrás de cada proyecto.',
+  openGraph: {
+    title: 'Proyectos de la comunidad | programaConNosotros',
+    description:
+      'Explorá los proyectos de software creados por miembros de la comunidad. Conocé las tecnologías utilizadas y las personas detrás de cada proyecto.',
+    images: [`${SITE_URL}/pcn-link-preview.png`],
+    url: `${SITE_URL}/proyectos`,
+    type: 'website',
+    siteName: 'programaConNosotros',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Proyectos de la comunidad | programaConNosotros',
+    description:
+      'Explorá los proyectos de software creados por miembros de la comunidad. Conocé las tecnologías utilizadas y las personas detrás de cada proyecto.',
+    images: [`${SITE_URL}/pcn-link-preview.png`],
+  },
+};
+
+const Proyectos = async () => {
+  const [projects, sessionId] = await Promise.all([
+    fetchPublicProjects(),
+    cookies().then((c) => c.get('sessionId')?.value),
+  ]);
+
+  const session = sessionId
+    ? await prisma.session.findUnique({ where: { id: sessionId }, include: { user: true } })
+    : null;
+
+  const isAdmin = session?.user.role === 'ADMIN';
+
+  return (
+    <>
+      <header className="flex h-16 shrink-0 items-center gap-2">
+        <div className="flex items-center gap-2 px-4">
+          <SidebarTrigger />
+          <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem className="hidden md:block">
+                <BreadcrumbLink href="/">Inicio</BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbSeparator className="hidden md:block" />
+              <BreadcrumbItem>
+                <BreadcrumbPage>Proyectos</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+        </div>
+      </header>
+      <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
+        <ProyectosAdminWrapper projects={projects} isAdmin={isAdmin} />
+      </div>
+    </>
+  );
+};
+
+export default Proyectos;

--- a/src/components/projects/project-form.tsx
+++ b/src/components/projects/project-form.tsx
@@ -1,0 +1,342 @@
+'use client';
+
+import { useState } from 'react';
+import { useFieldArray, useForm, useFormContext } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { toast } from 'sonner';
+import { Plus, Save, Trash2, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { FileUpload } from '@/components/ui/file-upload';
+import { SpeakerUserPicker } from '@/components/talks/speaker-user-picker';
+import { projectSchema, ProjectFormData } from '@/schemas/project-schema';
+import { createProject } from '@/actions/projects/create-project';
+import { updateProject } from '@/actions/projects/update-project';
+import { fetchPublicProjects } from '@/actions/projects/fetch-public-projects';
+
+type ProjectWithMembers = Awaited<ReturnType<typeof fetchPublicProjects>>[number];
+
+const EMPTY_MEMBER: NonNullable<ProjectFormData['members']>[number] = {
+  userId: null,
+  memberName: '',
+};
+
+function MemberFields({ index, onRemove }: { index: number; onRemove: () => void }) {
+  const { control, setValue } = useFormContext<ProjectFormData>();
+
+  return (
+    <div className="space-y-3 rounded-lg border p-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-medium">Miembro {index + 1}</h3>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onRemove}
+          className="text-destructive hover:text-destructive"
+        >
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <FormField
+        control={control}
+        name={`members.${index}.userId`}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Usuario registrado (opcional)</FormLabel>
+            <FormControl>
+              <SpeakerUserPicker
+                value={field.value ?? null}
+                onSelect={(user) => {
+                  field.onChange(user?.id ?? null);
+                  if (user) {
+                    setValue(`members.${index}.memberName`, user.name, {
+                      shouldValidate: true,
+                    });
+                  }
+                }}
+              />
+            </FormControl>
+            <FormDescription>
+              Buscá un usuario para vincular su perfil automáticamente.
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name={`members.${index}.memberName`}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Nombre</FormLabel>
+            <FormControl>
+              <Input placeholder="Ej: María García" {...field} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </div>
+  );
+}
+
+type Props = {
+  project?: ProjectWithMembers;
+  onSuccess?: () => void;
+  onCancel?: () => void;
+};
+
+export function ProjectForm({ project, onSuccess, onCancel }: Props) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [techInput, setTechInput] = useState('');
+
+  const form = useForm<ProjectFormData>({
+    resolver: zodResolver(projectSchema),
+    defaultValues: {
+      title: project?.title ?? '',
+      description: project?.description ?? '',
+      url: project?.url ?? '',
+      logoUrl: project?.logoUrl ?? '',
+      techStack: project?.techStack ?? [],
+      members: project?.members
+        ? project.members.map((m) => ({
+            userId: m.userId ?? null,
+            memberName: m.memberName,
+          }))
+        : [],
+      order: project?.order ?? 0,
+    },
+  });
+
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: 'members',
+  });
+
+  const techStack = form.watch('techStack') ?? [];
+
+  function addTech() {
+    const tag = techInput.trim();
+    if (!tag || techStack.includes(tag)) return;
+    form.setValue('techStack', [...techStack, tag], { shouldValidate: true });
+    setTechInput('');
+  }
+
+  function removeTech(tag: string) {
+    form.setValue(
+      'techStack',
+      techStack.filter((t) => t !== tag),
+      { shouldValidate: true },
+    );
+  }
+
+  const handleSubmit = async (values: ProjectFormData) => {
+    setIsSubmitting(true);
+    try {
+      if (project) {
+        await updateProject(project.id, values);
+        toast.success('Proyecto actualizado');
+      } else {
+        await createProject(values);
+        toast.success('Proyecto creado');
+      }
+      onSuccess?.();
+    } catch (error: any) {
+      toast.error(error.message || 'Error al guardar el proyecto');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-6">
+        <FormField
+          control={form.control}
+          name="title"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Nombre del proyecto</FormLabel>
+              <FormControl>
+                <Input placeholder="Ej: PCN Dashboard" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Descripción</FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="Describí brevemente de qué trata el proyecto..."
+                  className="min-h-[100px]"
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="url"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>URL del proyecto</FormLabel>
+              <FormControl>
+                <Input placeholder="https://github.com/usuario/proyecto" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="logoUrl"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Logo del proyecto</FormLabel>
+              <FormControl>
+                <FileUpload value={field.value ?? ''} onChange={field.onChange} folder="logos" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Tech stack tag input */}
+        <FormField
+          control={form.control}
+          name="techStack"
+          render={() => (
+            <FormItem>
+              <FormLabel>Stack tecnológico</FormLabel>
+              <div className="flex gap-2">
+                <Input
+                  placeholder="Ej: Next.js, PostgreSQL..."
+                  value={techInput}
+                  onChange={(e) => setTechInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      addTech();
+                    }
+                  }}
+                />
+                <Button type="button" variant="outline" onClick={addTech}>
+                  <Plus className="h-4 w-4" />
+                </Button>
+              </div>
+              {techStack.length > 0 && (
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {techStack.map((tag) => (
+                    <Badge key={tag} variant="secondary" className="flex items-center gap-1 pr-1">
+                      {tag}
+                      <button
+                        type="button"
+                        onClick={() => removeTech(tag)}
+                        className="ml-0.5 rounded-sm opacity-70 hover:opacity-100"
+                      >
+                        <X className="h-3 w-3" />
+                      </button>
+                    </Badge>
+                  ))}
+                </div>
+              )}
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Members */}
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <h3 className="text-base font-semibold">Participantes</h3>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => append({ ...EMPTY_MEMBER })}
+            >
+              <Plus className="mr-1 h-4 w-4" />
+              Agregar participante
+            </Button>
+          </div>
+          {fields.length === 0 && (
+            <p className="text-sm text-muted-foreground">
+              Sin participantes. Podés agregar los miembros que trabajaron en este proyecto.
+            </p>
+          )}
+          {fields.map((field, idx) => (
+            <MemberFields key={field.id} index={idx} onRemove={() => remove(idx)} />
+          ))}
+        </div>
+
+        <FormField
+          control={form.control}
+          name="order"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Orden</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  min={0}
+                  {...field}
+                  onChange={(e) => field.onChange(Number(e.target.value))}
+                />
+              </FormControl>
+              <FormDescription>Número menor aparece primero.</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <div className="flex gap-4">
+          <Button
+            type="submit"
+            variant="pcn"
+            className="flex-1"
+            loading={isSubmitting}
+            loadingText="Guardando..."
+          >
+            <Save className="mr-2 h-4 w-4" />
+            {project ? 'Actualizar proyecto' : 'Crear proyecto'}
+          </Button>
+          {onCancel && (
+            <Button
+              type="button"
+              variant="outline"
+              className="flex-1"
+              disabled={isSubmitting}
+              onClick={onCancel}
+            >
+              Cancelar
+            </Button>
+          )}
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/projects/proyectos-admin-wrapper.tsx
+++ b/src/components/projects/proyectos-admin-wrapper.tsx
@@ -1,0 +1,246 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { toast } from 'sonner';
+import { Edit, ExternalLink, MoreVertical, Plus, Rocket, Trash2, Users } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Heading2 } from '@/components/ui/heading-2';
+import { ProjectForm } from './project-form';
+import { deleteProject } from '@/actions/projects/delete-project';
+import { fetchPublicProjects } from '@/actions/projects/fetch-public-projects';
+
+type ProjectWithMembers = Awaited<ReturnType<typeof fetchPublicProjects>>[number];
+
+interface Props {
+  projects: ProjectWithMembers[];
+  isAdmin: boolean;
+}
+
+export function ProyectosAdminWrapper({ projects, isAdmin }: Props) {
+  const [showCreate, setShowCreate] = useState(false);
+  const [editingProject, setEditingProject] = useState<ProjectWithMembers | null>(null);
+  const [deletingProject, setDeletingProject] = useState<ProjectWithMembers | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    if (!deletingProject) return;
+    setIsDeleting(true);
+    try {
+      await deleteProject(deletingProject.id);
+      toast.success('Proyecto eliminado');
+      setDeletingProject(null);
+    } catch (error: any) {
+      toast.error(error.message || 'Error al eliminar el proyecto');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <div className="mt-4">
+      <div className="mb-4 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <div className="flex w-full flex-row items-center justify-between">
+          <Heading2 className="m-0 flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-lg border border-pcnPurple/30 bg-pcnPurple/10 dark:border-pcnGreen/50 dark:bg-pcnGreen/10 dark:shadow-[0_0_10px_rgba(4,244,190,0.4)]">
+              <Rocket className="h-5 w-5 text-pcnPurple dark:text-pcnGreen dark:drop-shadow-[0_0_8px_rgba(4,244,190,0.8)]" />
+            </div>
+            <span className="dark:drop-shadow-[0_0_12px_rgba(4,244,190,0.8)]">Proyectos</span>
+          </Heading2>
+
+          {isAdmin && (
+            <Button variant="pcn" onClick={() => setShowCreate(true)}>
+              <Plus className="mr-2 h-4 w-4" />
+              Nuevo proyecto
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {projects.length === 0 && (
+        <p className="text-muted-foreground">Todavía no hay proyectos publicados.</p>
+      )}
+
+      <div className="my-5 ml-0 grid grid-cols-1 gap-5 xl:grid-cols-2">
+        {projects.map((project) => (
+          <Card
+            key={project.id}
+            className="flex flex-col overflow-hidden border-2 border-transparent bg-gradient-to-br from-white to-gray-50 transition-all duration-300 hover:shadow-xl dark:border-neutral-800 dark:from-neutral-900 dark:to-neutral-800"
+          >
+            <div className="flex flex-col md:flex-row">
+              {/* Logo */}
+              {project.logoUrl && (
+                <div className="relative flex shrink-0 items-center justify-center bg-muted/30 md:w-40">
+                  <div className="relative h-32 w-32 md:aspect-square md:h-auto md:w-full">
+                    <Image
+                      src={project.logoUrl}
+                      alt={`Logo de ${project.title}`}
+                      fill
+                      className="object-contain p-4"
+                      sizes="(max-width: 768px) 128px, 160px"
+                    />
+                  </div>
+                </div>
+              )}
+
+              <div className="flex flex-1 flex-col">
+                <CardHeader>
+                  <div className="flex items-start justify-between gap-2">
+                    <CardTitle className="text-lg">{project.title}</CardTitle>
+                    {isAdmin && (
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0">
+                            <MoreVertical className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem onClick={() => setEditingProject(project)}>
+                            <Edit className="mr-2 h-4 w-4" />
+                            Editar
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onClick={() => setDeletingProject(project)}
+                            className="text-destructive focus:text-destructive"
+                          >
+                            <Trash2 className="mr-2 h-4 w-4" />
+                            Eliminar
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    )}
+                  </div>
+                </CardHeader>
+
+                <CardContent className="flex-1 space-y-3">
+                  <p className="line-clamp-3 text-sm text-muted-foreground">
+                    {project.description}
+                  </p>
+
+                  {/* Tech stack badges */}
+                  {project.techStack.length > 0 && (
+                    <div className="flex flex-wrap gap-1.5">
+                      {project.techStack.map((tag) => (
+                        <Badge key={tag} variant="secondary">
+                          {tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Members */}
+                  {project.members.length > 0 && (
+                    <div className="flex items-start gap-2">
+                      <Users className="mt-0.5 h-4 w-4 shrink-0 text-pcnPurple dark:text-pcnGreen" />
+                      <div className="flex min-w-0 flex-col gap-0.5">
+                        {project.members.map((member) =>
+                          member.user ? (
+                            <Link
+                              key={member.id}
+                              href={`/perfil/${member.user.id}`}
+                              className="text-sm text-muted-foreground hover:underline"
+                            >
+                              {member.memberName}
+                            </Link>
+                          ) : (
+                            <p key={member.id} className="text-sm text-muted-foreground">
+                              {member.memberName}
+                            </p>
+                          ),
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </CardContent>
+
+                <CardFooter className="mt-auto">
+                  <Link href={project.url} target="_blank" rel="noopener noreferrer">
+                    <Button variant="outline" className="flex items-center gap-2">
+                      Visitar proyecto
+                      <ExternalLink className="h-4 w-4 text-pcnPurple dark:text-pcnGreen" />
+                    </Button>
+                  </Link>
+                </CardFooter>
+              </div>
+            </div>
+          </Card>
+        ))}
+      </div>
+
+      {/* Create dialog */}
+      <Dialog open={showCreate} onOpenChange={setShowCreate}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[600px]">
+          <DialogHeader>
+            <DialogTitle>Nuevo proyecto</DialogTitle>
+          </DialogHeader>
+          <ProjectForm
+            onSuccess={() => setShowCreate(false)}
+            onCancel={() => setShowCreate(false)}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {/* Edit dialog */}
+      <Dialog open={!!editingProject} onOpenChange={(open) => !open && setEditingProject(null)}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[600px]">
+          <DialogHeader>
+            <DialogTitle>Editar proyecto</DialogTitle>
+          </DialogHeader>
+          {editingProject && (
+            <ProjectForm
+              project={editingProject}
+              onSuccess={() => setEditingProject(null)}
+              onCancel={() => setEditingProject(null)}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete confirmation */}
+      <AlertDialog
+        open={!!deletingProject}
+        onOpenChange={(open) => !open && setDeletingProject(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>¿Eliminar proyecto?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Esta acción eliminará permanentemente &quot;{deletingProject?.title}&quot;. No se
+              puede deshacer.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isDeleting ? 'Eliminando...' : 'Eliminar'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/components/ui/app-sidebar.tsx
+++ b/src/components/ui/app-sidebar.tsx
@@ -19,6 +19,7 @@ import {
   MessageCircle,
   MicVocal,
   Podcast,
+  Rocket,
   ScrollText,
   Send,
   Share2,
@@ -112,7 +113,7 @@ const getRecursosItems = () => [
   { title: 'Lectura', url: '/lectura', icon: BookOpen },
   { title: 'Especialidades', url: '/especialidades', icon: Layers },
   { title: 'Herramientas', url: '/herramientas', icon: Wrench },
-  { title: 'Proyectos', url: '/proyectos', icon: Code2 },
+  { title: 'Proyectos', url: '/proyectos', icon: Rocket },
   {
     title: 'Más recursos',
     icon: Library,

--- a/src/components/ui/app-sidebar.tsx
+++ b/src/components/ui/app-sidebar.tsx
@@ -112,6 +112,7 @@ const getRecursosItems = () => [
   { title: 'Lectura', url: '/lectura', icon: BookOpen },
   { title: 'Especialidades', url: '/especialidades', icon: Layers },
   { title: 'Herramientas', url: '/herramientas', icon: Wrench },
+  { title: 'Proyectos', url: '/proyectos', icon: Code2 },
   {
     title: 'Más recursos',
     icon: Library,

--- a/src/schemas/project-schema.ts
+++ b/src/schemas/project-schema.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+export const projectMemberSchema = z.object({
+  userId: z
+    .string()
+    .cuid()
+    .optional()
+    .nullable()
+    .transform((v) => (v === '' ? null : v ?? null)),
+  memberName: z
+    .string()
+    .min(2, { message: 'El nombre debe tener al menos 2 caracteres' })
+    .max(200, { message: 'El nombre no puede exceder 200 caracteres' }),
+});
+
+export const projectSchema = z.object({
+  title: z
+    .string()
+    .min(3, { message: 'El título debe tener al menos 3 caracteres' })
+    .max(200, { message: 'El título no puede exceder 200 caracteres' }),
+  description: z
+    .string()
+    .min(10, { message: 'La descripción debe tener al menos 10 caracteres' })
+    .max(2000, { message: 'La descripción no puede exceder 2000 caracteres' }),
+  url: z.string().url({ message: 'La URL del proyecto no es válida' }),
+  logoUrl: z
+    .string()
+    .url({ message: 'La URL del logo no es válida' })
+    .optional()
+    .or(z.literal(''))
+    .transform((val) => (val === '' ? undefined : val)),
+  techStack: z.array(z.string().min(1).max(50)).default([]),
+  members: z.array(projectMemberSchema).default([]),
+  order: z.number().int().min(0).default(0),
+});
+
+export type ProjectMemberFormData = z.input<typeof projectMemberSchema>;
+export type ProjectMemberData = z.infer<typeof projectMemberSchema>;
+export type ProjectFormData = z.input<typeof projectSchema>;
+export type ProjectData = z.infer<typeof projectSchema>;


### PR DESCRIPTION
## Summary

- Adds a new `/proyectos` page under the **Recursos** sidebar section to showcase software projects built by community members
- Full admin CRUD (create, update, delete) with read-only view for regular users
- Each project has: title, description, URL, logo (uploaded to S3), free-form tech stack badges, and tagged community members (linked to user profiles)

## Implementation

- **DB**: `Project` + `ProjectMember` models (mirrors the existing `Talk`/`TalkSpeaker` pattern), migration applied
- **Server actions**: `fetch-public-projects` (public), `create/update/delete-project` (admin-gated via `session.user.role === 'ADMIN'`)
- **Form**: logo upload via existing `FileUpload` + S3 presign flow (`folder="logos"`), free-form tag input for tech stack, user search/tagging via existing `SpeakerUserPicker`
- **UI**: card grid with tech badges, member links to `/perfil/{id}`, "Visitar proyecto" button; admin gets per-card edit/delete dropdown + "Nuevo proyecto" button
- **Sidebar**: `Proyectos` added as a top-level entry in Recursos (using existing `Code2` icon)

## Test plan

- [ ] Visit `/proyectos` as a non-authenticated user — page loads, no admin controls visible
- [ ] Log in as a non-admin — same read-only view
- [ ] Log in as an admin — "Nuevo proyecto" button appears; per-card edit/delete menu appears
- [ ] Create a project: upload a logo, add tech tags (Enter or button), tag a registered user via search picker + add a free-text contributor, save → card appears
- [ ] Edit a project: change tags and members, save → card reflects changes; tagged user links to `/perfil/{id}`
- [ ] Delete a project: confirm via `AlertDialog` → card disappears
- [ ] Sidebar shows "Proyectos" under Recursos and navigates to `/proyectos`